### PR TITLE
Feat #21 Presigned Url 반환 API 구현 및 스웨거 설정 추가

### DIFF
--- a/src/main/java/com/gachtaxi/global/common/image/ImageUtil.java
+++ b/src/main/java/com/gachtaxi/global/common/image/ImageUtil.java
@@ -1,0 +1,40 @@
+package com.gachtaxi.global.common.image;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class ImageUtil {
+
+    private final S3Presigner s3Presigner;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String generateUrl() {
+        String key = UUID.randomUUID().toString();
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        PutObjectPresignRequest request = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(5))
+                .putObjectRequest(putObjectRequest)
+                .build();
+
+        PresignedPutObjectRequest presignedUrlRequest = s3Presigner.presignPutObject(request);
+
+        return presignedUrlRequest.url().toString();
+    }
+}

--- a/src/main/java/com/gachtaxi/global/common/image/controller/ImageController.java
+++ b/src/main/java/com/gachtaxi/global/common/image/controller/ImageController.java
@@ -1,0 +1,30 @@
+package com.gachtaxi.global.common.image.controller;
+
+import com.gachtaxi.global.common.image.ImageUtil;
+import com.gachtaxi.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.gachtaxi.global.common.image.controller.ResponseMessage.PRESIGNED_URL_GENERATE_SUCCESS;
+import static org.springframework.http.HttpStatus.OK;
+
+@Tag(name = "IMAGE")
+@RestController
+@RequestMapping("/api/images")
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final ImageUtil imageUtil;
+
+    @GetMapping()
+    @Operation(summary = "Presigned Url 반환을 위한 요청 API 입니다.")
+    public ApiResponse<String> getPutUrl() {
+        String putUrl = imageUtil.generateUrl();
+
+        return ApiResponse.response(OK, PRESIGNED_URL_GENERATE_SUCCESS.getMessage(), putUrl);
+    }
+}

--- a/src/main/java/com/gachtaxi/global/common/image/controller/ResponseMessage.java
+++ b/src/main/java/com/gachtaxi/global/common/image/controller/ResponseMessage.java
@@ -1,0 +1,14 @@
+package com.gachtaxi.global.common.image.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseMessage {
+
+    PRESIGNED_URL_GENERATE_SUCCESS("Presigned url 발급에 성공했습니다.");
+
+    private final String message;
+
+}

--- a/src/main/java/com/gachtaxi/global/config/AwsS3Config.java
+++ b/src/main/java/com/gachtaxi/global/config/AwsS3Config.java
@@ -1,0 +1,32 @@
+package com.gachtaxi.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class AwsS3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secreteKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secreteKey);
+
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+}

--- a/src/main/java/com/gachtaxi/global/config/SwaggerConfig.java
+++ b/src/main/java/com/gachtaxi/global/config/SwaggerConfig.java
@@ -1,25 +1,47 @@
 package com.gachtaxi.global.config;
 
 import io.swagger.v3.oas.models.Components;
-import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import static com.gachtaxi.global.auth.jwt.util.JwtProvider.ACCESS_TOKEN_SUBJECT;
 
 @Configuration
 public class SwaggerConfig {
 
+    private static final String SCHEMA_NAME = "bearerAuth";
+
     @Bean
     public OpenAPI openAPI() {
+        SecurityScheme accessSecurityScheme = getAccessSecurityScheme();
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(SCHEMA_NAME);
+
         return new OpenAPI()
-                .components(new Components())
+                .addServersItem(new Server().url("/"))
+                .components(new Components()
+                        .addSecuritySchemes(SCHEMA_NAME, accessSecurityScheme))
+                .addSecurityItem(securityRequirement)
                 .info(apiInfo());
     }
 
-    private Info apiInfo(){
+    private Info apiInfo() {
         return new Info()
                 .title("GachTaxi API Specifications")
                 .description("가치택시 REST API 스웨거 명세서")
                 .version("1.0.0");
+    }
+
+    private SecurityScheme getAccessSecurityScheme() {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name(ACCESS_TOKEN_SUBJECT);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,3 +12,16 @@ springdoc:
 
 chat:
   topic: ${CHAT_TOPIC}
+
+cloud:
+  aws:
+    s3:
+      bucket: ${S3_BUCKET}
+    credentials:
+      access-key: ${S3_ACCESS_KEY}
+      secret-key: ${S3_SECRET_KEY}
+    region:
+      static: ap-northeast-2
+      auto: false
+    stack:
+      auto: false


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #20   
Close #


## 🚀 작업 내용
- AWS s3 설정 및 Presigned Url을 반환하는 API를 구현했습니다
- 임시 토큰으로 요청을 주기 때문에 별도로 경로를 해제하진 않았습니다
- 스웨거에서 JWT 액세스 토큰을 넣어서 API 테스트가 가능하도록 설정을 추가했습니다

- PUT 요청 가능 시간은 5분으로 설정해뒀습니다
- 파일명 관리의 의미를 느끼지 못해 UUID로 랜덤 생성된 URL을 만드는 것으로 했습니다

## 📸 스크린샷
- URL 요청
<img width="1060" alt="image" src="https://github.com/user-attachments/assets/6f3e1434-83e7-4568-8a8d-c95d02351e8a" />

- 결과
<img width="802" alt="image" src="https://github.com/user-attachments/assets/322a22f8-f0cb-46d7-a5fd-3ad9d3eb2ddd" />
<img width="662" alt="image" src="https://github.com/user-attachments/assets/05eb665d-cb3f-492f-a509-62fa44a20a9e" />


## 📢 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
