### PR TITLE
Feat #38 매칭 필터링 및 알고리즘 구현

### DIFF
--- a/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MatchingAlgorithmService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MatchingAlgorithmService.java
@@ -11,10 +11,12 @@ public interface MatchingAlgorithmService {
    * 방을 찾는 메서드
    * 이미 방에 들어가있는 멤버가 다시 요청했을 때 Optional.empty()를 반환하도록 로직을 구성해야함
    * @param userId 방에 들어가려는 사용자 ID
-   * @param startPoint 매칭 시작 지점 좌표
-   * @param destinationPoint 도착지 좌표
+   * @param startLongitude 시작 지점 경도
+   * @param startLatitude 시작 지점 위도
+   * @param destinationLongitude 도착 지점 경도
+   * @param destinationLatitude 도착 지점 위도
    * @param criteria 방 검색에 필요한 기타 조건 (태그 등)
    * @return Optional<FindRoomResult> - 매칭 가능한 방 정보가 있으면 값이 있고, 없으면 empty
    */
-  Optional<FindRoomResult> findRoom(Long userId, String startPoint, String destinationPoint, List<Tags> criteria);
+  Optional<FindRoomResult> findRoom(Long userId, double startLongitude, double startLatitude, double destinationLongitude, double destinationLatitude, List<Tags> criteria);
 }

--- a/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MatchingAlgorithmService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MatchingAlgorithmService.java
@@ -1,9 +1,11 @@
 package com.gachtaxi.domain.matching.algorithm.service;
 
 import com.gachtaxi.domain.matching.algorithm.dto.FindRoomResult;
+import com.gachtaxi.domain.matching.common.entity.MatchingRoom;
 import com.gachtaxi.domain.matching.common.entity.enums.Tags;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
 
 public interface MatchingAlgorithmService {
 
@@ -19,4 +21,13 @@ public interface MatchingAlgorithmService {
    * @return Optional<FindRoomResult> - 매칭 가능한 방 정보가 있으면 값이 있고, 없으면 empty
    */
   Optional<FindRoomResult> findRoom(Long userId, double startLongitude, double startLatitude, double destinationLongitude, double destinationLatitude, List<Tags> criteria);
+
+  /**
+   * 전체 매칭 방을 페이지 단위로 조회
+   *
+   * @param pageNumber 페이지 번호 (0부터 시작)
+   * @param pageSize   한 페이지에 포함될 매칭 방의 개수
+   * @return Page<MatchingRoom> - 페이지별 매칭 방 정보
+   */
+  Page<MatchingRoom> findMatchingRooms(int pageNumber, int pageSize);
 }

--- a/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MockMatchingAlgorithmService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MockMatchingAlgorithmService.java
@@ -32,8 +32,7 @@ public class MockMatchingAlgorithmService implements MatchingAlgorithmService {
     Members user = memberRepository.findById(userId)
             .orElseThrow(MemberNotFoundException::new);
 
-    boolean isAlreadyInRoom = matchingRoomRepository.existsByMemberInMatchingRoom(user);
-    if (isAlreadyInRoom) {
+    if (matchingRoomRepository.existsByMemberInMatchingRoom(user)) {
       return Optional.empty();
     }
     /*

--- a/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MockMatchingAlgorithmService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MockMatchingAlgorithmService.java
@@ -23,6 +23,8 @@ public class MockMatchingAlgorithmService implements MatchingAlgorithmService {
   private final MatchingRoomRepository matchingRoomRepository;
   private final MemberService memberService;
 
+  private static final double SEARCH_RADIUS = 300.0;
+
   @Override
   public Optional<FindRoomResult> findRoom(Long userId, double startLongitude, double startLatitude, double destinationLongitude, double destinationLatitude,
                                            List<Tags> criteria) {
@@ -41,7 +43,8 @@ public class MockMatchingAlgorithmService implements MatchingAlgorithmService {
               startLongitude,
               startLatitude,
               destinationLongitude,
-              destinationLatitude
+              destinationLatitude,
+              SEARCH_RADIUS
       );
     /*
       ACTIVE 상태인 방만 필터링

--- a/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MockMatchingAlgorithmService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MockMatchingAlgorithmService.java
@@ -3,6 +3,7 @@ package com.gachtaxi.domain.matching.algorithm.service;
 import com.gachtaxi.domain.matching.algorithm.dto.FindRoomResult;
 import com.gachtaxi.domain.matching.common.entity.MatchingRoom;
 import com.gachtaxi.domain.matching.common.entity.enums.Tags;
+import com.gachtaxi.domain.matching.common.exception.DuplicatedMatchingRoomException;
 import com.gachtaxi.domain.matching.common.exception.PageNotFoundException;
 import com.gachtaxi.domain.matching.common.repository.MatchingRoomRepository;
 import com.gachtaxi.domain.members.entity.Members;
@@ -31,7 +32,7 @@ public class MockMatchingAlgorithmService implements MatchingAlgorithmService {
     Members user = memberService.findById(userId);
 
     if (matchingRoomRepository.existsByMemberInMatchingRoom(user)) {
-      return Optional.empty();
+      throw new DuplicatedMatchingRoomException(); // * 추후 논의 후 리팩토링 필요 * 똑같은 조건으로 방 생성시 예외 던져주기
     }
     /*
      위치 정보를 이용한 방 검색(300M 이내)

--- a/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MockMatchingAlgorithmService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MockMatchingAlgorithmService.java
@@ -6,8 +6,7 @@ import com.gachtaxi.domain.matching.common.entity.enums.Tags;
 import com.gachtaxi.domain.matching.common.exception.PageNotFoundException;
 import com.gachtaxi.domain.matching.common.repository.MatchingRoomRepository;
 import com.gachtaxi.domain.members.entity.Members;
-import com.gachtaxi.domain.members.exception.MemberNotFoundException;
-import com.gachtaxi.domain.members.repository.MemberRepository;
+import com.gachtaxi.domain.members.service.MemberService;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +20,7 @@ import org.springframework.stereotype.Service;
 public class MockMatchingAlgorithmService implements MatchingAlgorithmService {
 
   private final MatchingRoomRepository matchingRoomRepository;
-  private final MemberRepository memberRepository;
+  private final MemberService memberService;
 
   @Override
   public Optional<FindRoomResult> findRoom(Long userId, double startLongitude, double startLatitude, double destinationLongitude, double destinationLatitude,
@@ -29,8 +28,7 @@ public class MockMatchingAlgorithmService implements MatchingAlgorithmService {
     /*
      사용자 ID로 사용자 정보 조회(이미 방에 참여하고 있는지 중복체크)
      */
-    Members user = memberRepository.findById(userId)
-            .orElseThrow(MemberNotFoundException::new);
+    Members user = memberService.findById(userId);
 
     if (matchingRoomRepository.existsByMemberInMatchingRoom(user)) {
       return Optional.empty();

--- a/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MockMatchingAlgorithmService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MockMatchingAlgorithmService.java
@@ -34,28 +34,27 @@ public class MockMatchingAlgorithmService implements MatchingAlgorithmService {
       return Optional.empty();
     }
     /*
-     태그 조건이 비어있는 경우에는 위치 정보만 이용한 방 검색(300M 이내, ACTIVE 상태)
+     위치 정보를 이용한 방 검색(300M 이내)
      */
-    List<MatchingRoom> matchingRooms;
-    if (criteria == null || criteria.isEmpty()) {
-      matchingRooms = matchingRoomRepository.findRoomsByStartAndDestination(
+    List<MatchingRoom> matchingRooms = matchingRoomRepository.findRoomsByStartAndDestination(
               startLongitude,
               startLatitude,
               destinationLongitude,
               destinationLatitude
       );
-      }
     /*
-     태그 조건이 있는 경우에 위치 정보와 태그 정보를 이용한 방 검색(300M 이내, ACTIVE 상태)
+      ACTIVE 상태인 방만 필터링
      */
-    else {
-      matchingRooms = matchingRoomRepository.findRoomsByStartAndDestinationAndTags(
-              startLongitude,
-              startLatitude,
-              destinationLongitude,
-              destinationLatitude,
-              criteria
-      );
+    matchingRooms = matchingRooms.stream()
+            .filter(MatchingRoom::isActiveMatchingRoom)
+            .toList();
+    /*
+     태그 조건이 있는 경우에 태그정보까지 필터링
+     */
+    if (criteria != null && !criteria.isEmpty()) {
+      matchingRooms = matchingRooms.stream()
+              .filter(room -> criteria.stream().anyMatch(room::containsTag))
+              .toList();
     }
     /*
      조건에 맞는 방이 있으면 첫 번째 방의 상세 정보 반환

--- a/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MockMatchingAlgorithmService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MockMatchingAlgorithmService.java
@@ -36,15 +36,29 @@ public class MockMatchingAlgorithmService implements MatchingAlgorithmService {
       return Optional.empty();
     }
     /*
-     출발지 기준 300m 이내 + 태그 조건에 맞는 방 검색
+     태그 조건이 비어있는 경우에는 위치 정보만 이용한 방 검색(300M 이내, ACTIVE 상태)
      */
-    List<MatchingRoom> matchingRooms = matchingRoomRepository.findRoomsByStartAndDestinationAndTags(
-            startLongitude,
-            startLatitude,
-            destinationLongitude,
-            destinationLatitude,
-            criteria
-    );
+    List<MatchingRoom> matchingRooms;
+    if (criteria == null || criteria.isEmpty()) {
+      matchingRooms = matchingRoomRepository.findRoomsByStartAndDestination(
+              startLongitude,
+              startLatitude,
+              destinationLongitude,
+              destinationLatitude
+      );
+      }
+    /*
+     태그 조건이 있는 경우에 위치 정보와 태그 정보를 이용한 방 검색(300M 이내, ACTIVE 상태)
+     */
+    else {
+      matchingRooms = matchingRoomRepository.findRoomsByStartAndDestinationAndTags(
+              startLongitude,
+              startLatitude,
+              destinationLongitude,
+              destinationLatitude,
+              criteria
+      );
+    }
     /*
      조건에 맞는 방이 있으면 첫 번째 방의 상세 정보 반환
      */

--- a/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MockMatchingAlgorithmService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MockMatchingAlgorithmService.java
@@ -4,6 +4,9 @@ import com.gachtaxi.domain.matching.algorithm.dto.FindRoomResult;
 import com.gachtaxi.domain.matching.common.entity.MatchingRoom;
 import com.gachtaxi.domain.matching.common.entity.enums.Tags;
 import com.gachtaxi.domain.matching.common.repository.MatchingRoomRepository;
+import com.gachtaxi.domain.members.entity.Members;
+import com.gachtaxi.domain.members.exception.MemberNotFoundException;
+import com.gachtaxi.domain.members.repository.MemberRepository;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -14,18 +17,46 @@ import org.springframework.stereotype.Service;
 public class MockMatchingAlgorithmService implements MatchingAlgorithmService {
 
   private final MatchingRoomRepository matchingRoomRepository;
+  private final MemberRepository memberRepository;
 
   @Override
-  public Optional<FindRoomResult> findRoom(Long userId, String startPoint, String destinationPoint, List<Tags> criteria) {
-    List<MatchingRoom> matchingRoomList = this.matchingRoomRepository.findAll();
-    if (!matchingRoomList.isEmpty()) {
-      MatchingRoom matchingRoom = matchingRoomList.get(0);
-      return Optional.of(
-          FindRoomResult.builder()
-              .roomId(matchingRoom.getId())
-              .maxCapacity(matchingRoom.getCapacity())
-              .build());
+  public Optional<FindRoomResult> findRoom(Long userId, double startLongitude, double startLatitude, double destinationLongitude, double destinationLatitude,
+                                           List<Tags> criteria) {
+    /*
+     사용자 ID로 사용자 정보 조회(이미 방에 참여하고 있는지 중복체크)
+     */
+    Members user = memberRepository.findById(userId)
+            .orElseThrow(MemberNotFoundException::new);
+
+    boolean isAlreadyInRoom = matchingRoomRepository.existsByMemberInMatchingRoom(user);
+    if (isAlreadyInRoom) {
+      return Optional.empty();
     }
+    /*
+     출발지 기준 300m 이내 + 태그 조건에 맞는 방 검색
+     */
+    List<MatchingRoom> matchingRooms = matchingRoomRepository.findRoomsByStartAndDestinationAndTags(
+            startLongitude,
+            startLatitude,
+            destinationLongitude,
+            destinationLatitude,
+            criteria
+    );
+    /*
+     조건에 맞는 방이 있으면 첫 번째 방의 상세 정보 반환
+     */
+    if (!matchingRooms.isEmpty()) {
+      MatchingRoom room = matchingRooms.get(0);
+      return Optional.of(
+              FindRoomResult.builder()
+                      .roomId(room.getId())
+                      .maxCapacity(room.getCapacity())
+                      .build()
+      );
+    }
+    /*
+     조건에 맞는 방이 없으면 empty 반환
+     */
     return Optional.empty();
   }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MockMatchingAlgorithmService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MockMatchingAlgorithmService.java
@@ -62,12 +62,7 @@ public class MockMatchingAlgorithmService implements MatchingAlgorithmService {
      */
     if (!matchingRooms.isEmpty()) {
       MatchingRoom room = matchingRooms.get(0);
-      return Optional.of(
-              FindRoomResult.builder()
-                      .roomId(room.getId())
-                      .maxCapacity(room.getCapacity())
-                      .build()
-      );
+      return Optional.of(room.toFindRoomResult());
     }
     /*
      조건에 맞는 방이 없으면 empty 반환

--- a/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MockMatchingAlgorithmService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MockMatchingAlgorithmService.java
@@ -3,6 +3,7 @@ package com.gachtaxi.domain.matching.algorithm.service;
 import com.gachtaxi.domain.matching.algorithm.dto.FindRoomResult;
 import com.gachtaxi.domain.matching.common.entity.MatchingRoom;
 import com.gachtaxi.domain.matching.common.entity.enums.Tags;
+import com.gachtaxi.domain.matching.common.exception.PageNotFoundException;
 import com.gachtaxi.domain.matching.common.repository.MatchingRoomRepository;
 import com.gachtaxi.domain.members.entity.Members;
 import com.gachtaxi.domain.members.exception.MemberNotFoundException;
@@ -10,6 +11,9 @@ import com.gachtaxi.domain.members.repository.MemberRepository;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -59,4 +63,16 @@ public class MockMatchingAlgorithmService implements MatchingAlgorithmService {
      */
     return Optional.empty();
   }
+  @Override
+  public Page<MatchingRoom> findMatchingRooms(int pageNumber, int pageSize) {
+
+    if (pageNumber < 0) {
+      throw new PageNotFoundException();
+    }
+
+    PageRequest pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "id"));
+
+    return matchingRoomRepository.findAll(pageable);
+  }
+
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
@@ -1,6 +1,7 @@
 package com.gachtaxi.domain.matching.common.entity;
 
 import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomStatus;
+import com.gachtaxi.domain.matching.common.entity.enums.Tags;
 import com.gachtaxi.domain.members.entity.Members;
 import com.gachtaxi.global.common.entity.BaseEntity;
 import jakarta.persistence.CascadeType;
@@ -58,5 +59,9 @@ public class MatchingRoom extends BaseEntity {
 
   public boolean isActiveMatchingRoom() {
     return this.matchingRoomStatus == MatchingRoomStatus.ACTIVE;
+  }
+  public boolean containsTag(Tags tag) {
+    return this.matchingRoomTagInfo.stream()
+            .anyMatch(tagInfo -> tagInfo.matchesTag(tag));
   }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
@@ -1,5 +1,6 @@
 package com.gachtaxi.domain.matching.common.entity;
 
+import com.gachtaxi.domain.matching.algorithm.dto.FindRoomResult;
 import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomStatus;
 import com.gachtaxi.domain.matching.common.entity.enums.Tags;
 import com.gachtaxi.domain.members.entity.Members;
@@ -63,5 +64,11 @@ public class MatchingRoom extends BaseEntity {
   public boolean containsTag(Tags tag) {
     return this.matchingRoomTagInfo.stream()
             .anyMatch(tagInfo -> tagInfo.matchesTag(tag));
+  }
+  public FindRoomResult toFindRoomResult() {
+    return FindRoomResult.builder()
+            .roomId(this.getId())
+            .maxCapacity(this.getCapacity())
+            .build();
   }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoomTagInfo.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoomTagInfo.java
@@ -24,4 +24,8 @@ public class MatchingRoomTagInfo extends BaseEntity {
 
   @Enumerated(EnumType.STRING)
   private Tags tags;
+
+  public boolean matchesTag(Tags tag) {
+    return this.tags == tag;
+  }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/entity/Route.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/entity/Route.java
@@ -15,9 +15,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Route extends BaseEntity {
 
-  private String startLocationCoordinate;
+  private double startLongitude;
+  private double startLatitude;
   private String startLocationName;
 
-  private String endLocationCoordinate;
+  private double endLongitude;
+  private double endLatitude;
   private String endLocationName;
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/exception/DuplicatedMatchingRoomException.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/exception/DuplicatedMatchingRoomException.java
@@ -1,0 +1,12 @@
+package com.gachtaxi.domain.matching.common.exception;
+
+import static com.gachtaxi.domain.matching.common.exception.ErrorMessage.DUPLICATED_MATCHING_ROOM;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import com.gachtaxi.global.common.exception.BaseException;
+
+public class DuplicatedMatchingRoomException extends BaseException {
+    public DuplicatedMatchingRoomException() {
+        super(BAD_REQUEST, DUPLICATED_MATCHING_ROOM.getMessage());
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/matching/common/exception/ErrorMessage.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/exception/ErrorMessage.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public enum ErrorMessage {
 
   NO_SUCH_MATCHING_ROOM("해당 매칭 방이 존재하지 않습니다."),
-  NOT_ACTIVE_MATCHING_ROOM("열린 매칭 방이 아닙니다.");
+  NOT_ACTIVE_MATCHING_ROOM("열린 매칭 방이 아닙니다."),
+  NOT_FOUND_PAGE("페이지 번호는 0 이상이어야 합니다.");
 
   private final String message;
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/exception/ErrorMessage.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/exception/ErrorMessage.java
@@ -9,6 +9,7 @@ public enum ErrorMessage {
 
   NO_SUCH_MATCHING_ROOM("해당 매칭 방이 존재하지 않습니다."),
   NOT_ACTIVE_MATCHING_ROOM("열린 매칭 방이 아닙니다."),
+  DUPLICATED_MATCHING_ROOM("이미 존재하는 매칭 방입니다."),
   NOT_FOUND_PAGE("페이지 번호는 0 이상이어야 합니다.");
 
   private final String message;

--- a/src/main/java/com/gachtaxi/domain/matching/common/exception/PageNotFoundException.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/exception/PageNotFoundException.java
@@ -1,0 +1,10 @@
+package com.gachtaxi.domain.matching.common.exception;
+
+import com.gachtaxi.global.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class PageNotFoundException extends BaseException {
+    public PageNotFoundException() {
+        super(HttpStatus.NOT_FOUND, ErrorMessage.NOT_FOUND_PAGE.getMessage());
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/matching/common/repository/MatchingRoomRepository.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/repository/MatchingRoomRepository.java
@@ -1,7 +1,6 @@
 package com.gachtaxi.domain.matching.common.repository;
 
 import com.gachtaxi.domain.matching.common.entity.MatchingRoom;
-import com.gachtaxi.domain.matching.common.entity.enums.Tags;
 import com.gachtaxi.domain.members.entity.Members;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,25 +11,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MatchingRoomRepository extends JpaRepository<MatchingRoom, Long> {
     @Query("SELECT r FROM MatchingRoom r " +
-            "JOIN r.matchingRoomTagInfo ti " +
             "WHERE " +
             "FUNCTION('ST_Distance_Sphere', FUNCTION('POINT', :startLongitude, :startLatitude), FUNCTION('POINT', r.route.startLongitude, r.route.startLatitude)) <= 300 " +
-            "AND FUNCTION('ST_Distance_Sphere', FUNCTION('POINT', :destinationLongitude, :destinationLatitude), FUNCTION('POINT', r.route.endLongitude, r.route.endLatitude)) <= 300 " +
-            "AND ti.tags IN (:tags) " +
-            "AND r.matchingRoomStatus = 'ACTIVE'")
-    List<MatchingRoom> findRoomsByStartAndDestinationAndTags(
-            @Param("startLongitude") double startLongitude,
-            @Param("startLatitude") double startLatitude,
-            @Param("destinationLongitude") double destinationLongitude,
-            @Param("destinationLatitude") double destinationLatitude,
-            @Param("tags") List<Tags> tags
-    );
-
-    @Query("SELECT r FROM MatchingRoom r " +
-            "WHERE " +
-            "FUNCTION('ST_Distance_Sphere', FUNCTION('POINT', :startLongitude, :startLatitude), FUNCTION('POINT', r.route.startLongitude, r.route.startLatitude)) <= 300 " +
-            "AND FUNCTION('ST_Distance_Sphere', FUNCTION('POINT', :destinationLongitude, :destinationLatitude), FUNCTION('POINT', r.route.endLongitude, r.route.endLatitude)) <= 300 " +
-            "AND r.matchingRoomStatus = 'ACTIVE'")
+            "AND FUNCTION('ST_Distance_Sphere', FUNCTION('POINT', :destinationLongitude, :destinationLatitude), FUNCTION('POINT', r.route.endLongitude, r.route.endLatitude)) <= 300 ")
     List<MatchingRoom> findRoomsByStartAndDestination(
             @Param("startLongitude") double startLongitude,
             @Param("startLatitude") double startLatitude,

--- a/src/main/java/com/gachtaxi/domain/matching/common/repository/MatchingRoomRepository.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/repository/MatchingRoomRepository.java
@@ -1,10 +1,33 @@
 package com.gachtaxi.domain.matching.common.repository;
 
 import com.gachtaxi.domain.matching.common.entity.MatchingRoom;
+import com.gachtaxi.domain.matching.common.entity.enums.Tags;
+import com.gachtaxi.domain.members.entity.Members;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MatchingRoomRepository extends JpaRepository<MatchingRoom, Long> {
+    @Query("SELECT r FROM MatchingRoom r " +
+            "JOIN r.matchingRoomTagInfo ti " +
+            "WHERE " +
+            "FUNCTION('ST_Distance_Sphere', FUNCTION('POINT', :startLongitude, :startLatitude), FUNCTION('POINT', r.route.startLongitude, r.route.startLatitude)) <= 300 " +
+            "AND FUNCTION('ST_Distance_Sphere', FUNCTION('POINT', :destinationLongitude, :destinationLatitude), FUNCTION('POINT', r.route.endLongitude, r.route.endLatitude)) <= 300 " +
+            "AND ti.tags IN (:tags) " +
+            "AND r.matchingRoomStatus = 'ACTIVE'")
+    List<MatchingRoom> findRoomsByStartAndDestinationAndTags(
+            @Param("startLongitude") double startLongitude,
+            @Param("startLatitude") double startLatitude,
+            @Param("destinationLongitude") double destinationLongitude,
+            @Param("destinationLatitude") double destinationLatitude,
+            @Param("tags") List<Tags> tags
+    );
 
+    @Query("SELECT CASE WHEN COUNT(m) > 0 THEN true ELSE false END " +
+            "FROM MatchingRoom r JOIN r.memberMatchingRoomChargingInfo m " +
+            "WHERE m.members = :user")
+    boolean existsByMemberInMatchingRoom(@Param("user") Members user);
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/repository/MatchingRoomRepository.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/repository/MatchingRoomRepository.java
@@ -12,13 +12,14 @@ import org.springframework.stereotype.Repository;
 public interface MatchingRoomRepository extends JpaRepository<MatchingRoom, Long> {
     @Query("SELECT r FROM MatchingRoom r " +
             "WHERE " +
-            "FUNCTION('ST_Distance_Sphere', FUNCTION('POINT', :startLongitude, :startLatitude), FUNCTION('POINT', r.route.startLongitude, r.route.startLatitude)) <= 300 " +
-            "AND FUNCTION('ST_Distance_Sphere', FUNCTION('POINT', :destinationLongitude, :destinationLatitude), FUNCTION('POINT', r.route.endLongitude, r.route.endLatitude)) <= 300 ")
+            "FUNCTION('ST_Distance_Sphere', FUNCTION('POINT', :startLongitude, :startLatitude), FUNCTION('POINT', r.route.startLongitude, r.route.startLatitude)) <= :radius " +
+            "AND FUNCTION('ST_Distance_Sphere', FUNCTION('POINT', :destinationLongitude, :destinationLatitude), FUNCTION('POINT', r.route.endLongitude, r.route.endLatitude)) <= :radius ")
     List<MatchingRoom> findRoomsByStartAndDestination(
             @Param("startLongitude") double startLongitude,
             @Param("startLatitude") double startLatitude,
             @Param("destinationLongitude") double destinationLongitude,
-            @Param("destinationLatitude") double destinationLatitude
+            @Param("destinationLatitude") double destinationLatitude,
+            @Param("radius") double radius
     );
     @Query("SELECT CASE WHEN COUNT(m) > 0 THEN true ELSE false END " +
             "FROM MatchingRoom r JOIN r.memberMatchingRoomChargingInfo m " +

--- a/src/main/java/com/gachtaxi/domain/matching/common/repository/MatchingRoomRepository.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/repository/MatchingRoomRepository.java
@@ -26,6 +26,17 @@ public interface MatchingRoomRepository extends JpaRepository<MatchingRoom, Long
             @Param("tags") List<Tags> tags
     );
 
+    @Query("SELECT r FROM MatchingRoom r " +
+            "WHERE " +
+            "FUNCTION('ST_Distance_Sphere', FUNCTION('POINT', :startLongitude, :startLatitude), FUNCTION('POINT', r.route.startLongitude, r.route.startLatitude)) <= 300 " +
+            "AND FUNCTION('ST_Distance_Sphere', FUNCTION('POINT', :destinationLongitude, :destinationLatitude), FUNCTION('POINT', r.route.endLongitude, r.route.endLatitude)) <= 300 " +
+            "AND r.matchingRoomStatus = 'ACTIVE'")
+    List<MatchingRoom> findRoomsByStartAndDestination(
+            @Param("startLongitude") double startLongitude,
+            @Param("startLatitude") double startLatitude,
+            @Param("destinationLongitude") double destinationLongitude,
+            @Param("destinationLatitude") double destinationLatitude
+    );
     @Query("SELECT CASE WHEN COUNT(m) > 0 THEN true ELSE false END " +
             "FROM MatchingRoom r JOIN r.memberMatchingRoomChargingInfo m " +
             "WHERE m.members = :user")

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/AutoMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/AutoMatchingService.java
@@ -42,9 +42,17 @@ public class AutoMatchingService {
       AutoMatchingPostRequest autoMatchingPostRequest
   ) {
     List<Tags> criteria = autoMatchingPostRequest.getCriteria();
+
+    String[] startCoordinates = autoMatchingPostRequest.startPoint().split(",");
+    double startLongitude = Double.parseDouble(startCoordinates[0]);
+    double startLatitude = Double.parseDouble(startCoordinates[1]);
+
+    String[] destinationCoordinates = autoMatchingPostRequest.destinationPoint().split(",");
+    double destinationLongitude = Double.parseDouble(destinationCoordinates[0]);
+    double destinationLatitude = Double.parseDouble(destinationCoordinates[1]);
+
     Optional<FindRoomResult> optionalRoom =
-        this.matchingAlgorithmService.findRoom(memberId, autoMatchingPostRequest.startPoint(),
-            autoMatchingPostRequest.destinationPoint(), criteria);
+        this.matchingAlgorithmService.findRoom(memberId, startLongitude, startLatitude, destinationLongitude, destinationLatitude, criteria);
 
     optionalRoom
         .ifPresentOrElse(

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/MatchingRoomService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/MatchingRoomService.java
@@ -57,13 +57,22 @@ public class MatchingRoomService {
   }
 
   private Route saveRoute(MatchRoomCreatedEvent matchRoomCreatedEvent) {
-    Route route = Route.builder()
-        .startLocationCoordinate(matchRoomCreatedEvent.startPoint())
-        .startLocationName(matchRoomCreatedEvent.startName())
-        .endLocationCoordinate(matchRoomCreatedEvent.destinationPoint())
-        .endLocationName(matchRoomCreatedEvent.destinationName())
-        .build();
+    String[] startCoordinates = matchRoomCreatedEvent.startPoint().split(",");
+    double startLongitude = Double.parseDouble(startCoordinates[0]);
+    double startLatitude = Double.parseDouble(startCoordinates[1]);
 
+    String[] endCoordinates = matchRoomCreatedEvent.destinationPoint().split(",");
+    double endLongitude = Double.parseDouble(endCoordinates[0]);
+    double endLatitude = Double.parseDouble(endCoordinates[1]);
+
+    Route route = Route.builder()
+            .startLongitude(startLongitude)
+            .startLatitude(startLatitude)
+            .startLocationName(matchRoomCreatedEvent.startName())
+            .endLongitude(endLongitude)
+            .endLatitude(endLatitude)
+            .endLocationName(matchRoomCreatedEvent.destinationName())
+            .build();
     return this.routeRepository.save(route);
   }
 


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #30 
Close #

## 🚀 작업 내용
- [x] 사용자가 입력한 출발지, 도착지, 태그 조건에 맞는 활성 상태의 매칭 방을 검색하는 로직(findRoom 메서드)
*거리 조건은 300m 이내로 설정했고, 태그가 비어있는 경우에도 처리할 수 있도록 설정하였습니다
1. 멤버 아이디로 사용자 조회 및, 해당 특정 사용자가 방에 이미 방에 존재하는지 조회
2. ST_Distance_Sphere를 활용하여 출발지(300m 이내) 도착지(300m 이내)의 매칭 방을 필터링
3. 검색된 매칭 방 리스트에서 ACTIVE 상태인 방만 검색되도록 필터링
4. 태그 조건(criteria)이 주어진 경우, 태그 조건을 만족하는 방만 추가로 필터링
5. 위 조건에 맞는 방이 있으면 해당 방에 참가할 수 있도록 방의 정보를 조회
6. 조건에 맞는 방이 없다면 해당 방을 생성

- [x] 전체 매칭방을 리스트로 조회(페이지네이션 방식)
1. 페이지 번호랑 페이지 사이즈를 입력받아 조회
2. 페이지 번호가 유효하지 않은 경우 예외처리
3. 매칭 방의 정렬 기준은 id를 기준으로 내림차순으로 정렬
4. pageable로 매칭방의 리스트를 반환

## 📸 스크린샷
SSE 구독 후 포스트맨에서 테스트 진행했습니다
![image](https://github.com/user-attachments/assets/da7e0625-9902-4bd5-bc1f-fed4fe3a7bdd)

DB에 매칭방 생성까지 확인했습니다
<img width="1390" alt="image" src="https://github.com/user-attachments/assets/55311321-0d3d-4875-8159-95701ad70811" />

추가로 동일한 유저가 똑같은 조건의 방을 생성하려고 할시, 이미 존재하는 매칭방이라는 예외를 던져주도록 설계했습니다
![image](https://github.com/user-attachments/assets/6796eff9-ed9f-4c62-b607-084cc8e1826f)

## 📢 리뷰 요구사항
주영님과 충돌을 방지하고자 매칭시 필터링 로직이랑 전체 매칭방 리스트 조회 먼저 해당 PR에서 작업해서 머지하도록 하고,
블랙리스트와 친구추가는 별도의 이슈를 생성해서 추후에 작업하도록 협의했습니다

현재 저희가 출발지(가천대학교 정문, 1번출구) 와 도착지(가천대학교 기숙사, AI 공학관)로 정해져있는 설계였기에 
Haversine이랑 Radian을 통한 위도 경도 계산법은 사용하지 않았습니다
하지만 추후에  앱으로 마이그레이션 후  출발지와 도착지를 지도에서 동적으로 선택할 수 있도록 확장되는 경우에는 리팩토링이 필요해보입니다