### PR TITLE
Feat #42 채팅 메시지 읽음 처리

### DIFF
--- a/src/main/java/com/gachtaxi/domain/chat/dto/request/ChatMessage.java
+++ b/src/main/java/com/gachtaxi/domain/chat/dto/request/ChatMessage.java
@@ -1,5 +1,7 @@
 package com.gachtaxi.domain.chat.dto.request;
 
+import com.gachtaxi.domain.chat.dto.response.ReadMessageRange;
+import com.gachtaxi.domain.chat.entity.ChattingMessage;
 import com.gachtaxi.domain.chat.entity.enums.MessageType;
 import lombok.Builder;
 
@@ -7,30 +9,35 @@ import java.time.LocalDateTime;
 
 @Builder
 public record ChatMessage(
+        String messageId,
         Long roomId,
         Long senderId,
         String senderName,
         String message,
+        ReadMessageRange range,
+        Long unreadCount,
         LocalDateTime timeStamp,
         MessageType messageType
 ) {
-    public static ChatMessage of(ChatMessageRequest request, long roomId, long senderId, String senderName) {
+    public static ChatMessage from(ChattingMessage chattingMessage) {
         return ChatMessage.builder()
-                .roomId(roomId)
-                .senderId(senderId)
-                .senderName(senderName)
-                .message(request.message())
-                .timeStamp(LocalDateTime.now())
-                .messageType(MessageType.MESSAGE)
+                .messageId(chattingMessage.getId())
+                .roomId(chattingMessage.getRoomId())
+                .senderId(chattingMessage.getSenderId())
+                .senderName(chattingMessage.getSenderName())
+                .message(chattingMessage.getMessage())
+                .unreadCount(chattingMessage.getUnreadCount())
+                .timeStamp(chattingMessage.getTimeStamp())
+                .messageType(chattingMessage.getMessageType())
                 .build();
     }
 
-    public static ChatMessage of(long roomId, Long senderId, String senderName, String message, MessageType messageType) {
+    public static ChatMessage of(long roomId, Long senderId, String senderName, ReadMessageRange range, MessageType messageType) {
         return ChatMessage.builder()
                 .roomId(roomId)
                 .senderId(senderId)
                 .senderName(senderName)
-                .message(message)
+                .range(range)
                 .timeStamp(LocalDateTime.now())
                 .messageType(messageType)
                 .build();

--- a/src/main/java/com/gachtaxi/domain/chat/dto/response/ChatResponse.java
+++ b/src/main/java/com/gachtaxi/domain/chat/dto/response/ChatResponse.java
@@ -16,7 +16,7 @@ public record ChatResponse(
     public static ChatResponse of(ChattingParticipant chattingParticipant, List<ChattingMessageResponse> chattingMessages, ChatPageableResponse chatPageableResponse) {
         return ChatResponse.builder()
                 .memberId(chattingParticipant.getMembers().getId())
-                .disconnectedAt(chattingParticipant.getDisconnectedAt())
+                .disconnectedAt(chattingParticipant.getLastReadAt())
                 .chattingMessage(chattingMessages)
                 .pageable(chatPageableResponse)
                 .build();

--- a/src/main/java/com/gachtaxi/domain/chat/dto/response/ChattingMessageResponse.java
+++ b/src/main/java/com/gachtaxi/domain/chat/dto/response/ChattingMessageResponse.java
@@ -8,15 +8,21 @@ import java.time.LocalDateTime;
 
 @Builder
 public record ChattingMessageResponse(
+        String messageId,
+        Long senderId,
         String senderName,
         String message,
+        Long unreadCount,
         LocalDateTime timeStamp,
         MessageType messageType
 ) {
     public static ChattingMessageResponse from(ChattingMessage chattingMessage) {
         return ChattingMessageResponse.builder()
+                .messageId(chattingMessage.getId())
+                .senderId(chattingMessage.getSenderId())
                 .senderName(chattingMessage.getSenderName())
                 .message(chattingMessage.getMessage())
+                .unreadCount(chattingMessage.getUnreadCount())
                 .timeStamp(chattingMessage.getTimeStamp())
                 .messageType(chattingMessage.getMessageType())
                 .build();

--- a/src/main/java/com/gachtaxi/domain/chat/dto/response/ReadMessageRange.java
+++ b/src/main/java/com/gachtaxi/domain/chat/dto/response/ReadMessageRange.java
@@ -1,0 +1,12 @@
+package com.gachtaxi.domain.chat.dto.response;
+
+import org.springframework.data.util.Pair;
+
+public record ReadMessageRange(
+        String startMessageId,
+        String endMessageId
+) {
+    public static ReadMessageRange of(Pair<String, String> pair) {
+        return new ReadMessageRange(pair.getFirst(), pair.getSecond());
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/chat/dto/response/ReadMessageRange.java
+++ b/src/main/java/com/gachtaxi/domain/chat/dto/response/ReadMessageRange.java
@@ -6,7 +6,7 @@ public record ReadMessageRange(
         String startMessageId,
         String endMessageId
 ) {
-    public static ReadMessageRange of(Pair<String, String> pair) {
+    public static ReadMessageRange from(Pair<String, String> pair) {
         return new ReadMessageRange(pair.getFirst(), pair.getSecond());
     }
 }

--- a/src/main/java/com/gachtaxi/domain/chat/entity/ChattingMessage.java
+++ b/src/main/java/com/gachtaxi/domain/chat/entity/ChattingMessage.java
@@ -1,6 +1,6 @@
 package com.gachtaxi.domain.chat.entity;
 
-import com.gachtaxi.domain.chat.dto.request.ChatMessage;
+import com.gachtaxi.domain.chat.dto.request.ChatMessageRequest;
 import com.gachtaxi.domain.chat.entity.enums.MessageType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
@@ -29,6 +29,8 @@ public class ChattingMessage {
 
     private String message;
 
+    private Long unreadCount;
+
     private MessageType messageType;
 
     private LocalDateTime timeStamp;
@@ -36,14 +38,26 @@ public class ChattingMessage {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-    public static ChattingMessage from(ChatMessage chatMessage) {
+    public static ChattingMessage of(ChatMessageRequest request, long roomId, long senderId, String senderName, long unreadCount) {
         return ChattingMessage.builder()
-                .senderId(chatMessage.senderId())
-                .senderName(chatMessage.senderName())
-                .roomId(chatMessage.roomId())
-                .message(chatMessage.message())
-                .timeStamp(chatMessage.timeStamp())
-                .messageType(chatMessage.messageType())
+                .senderId(senderId)
+                .senderName(senderName)
+                .roomId(roomId)
+                .message(request.message())
+                .unreadCount(unreadCount)
+                .messageType(MessageType.MESSAGE)
+                .timeStamp(LocalDateTime.now())
+                .build();
+    }
+
+    public static ChattingMessage of(long roomId, Long senderId, String senderName, String message, MessageType messageType) {
+        return ChattingMessage.builder()
+                .senderId(senderId)
+                .senderName(senderName)
+                .roomId(roomId)
+                .message(message)
+                .messageType(messageType)
+                .timeStamp(LocalDateTime.now())
                 .build();
     }
 }

--- a/src/main/java/com/gachtaxi/domain/chat/entity/ChattingParticipant.java
+++ b/src/main/java/com/gachtaxi/domain/chat/entity/ChattingParticipant.java
@@ -32,7 +32,8 @@ public class ChattingParticipant extends BaseEntity {
     @Column(updatable = false)
     private LocalDateTime joinedAt;
 
-    private LocalDateTime disconnectedAt;
+    @CreatedDate
+    private LocalDateTime lastReadAt;
 
     public static ChattingParticipant of(ChattingRoom chattingRoom, Members members) {
         return ChattingParticipant.builder()
@@ -41,11 +42,15 @@ public class ChattingParticipant extends BaseEntity {
                 .build();
     }
 
+    public void reSubscribe() {
+        this.lastReadAt = LocalDateTime.now();
+    }
+
     public void unsubscribe() {
-        this.disconnectedAt = LocalDateTime.now();
+        this.lastReadAt = LocalDateTime.now();
     }
 
     public void disconnect() {
-        this.disconnectedAt = LocalDateTime.now();
+        this.lastReadAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/gachtaxi/domain/chat/entity/ChattingParticipant.java
+++ b/src/main/java/com/gachtaxi/domain/chat/entity/ChattingParticipant.java
@@ -1,12 +1,12 @@
 package com.gachtaxi.domain.chat.entity;
 
-import com.gachtaxi.domain.chat.entity.enums.ChatStatus;
-import com.gachtaxi.domain.chat.exception.UnSubscriptionException;
 import com.gachtaxi.domain.members.entity.Members;
 import com.gachtaxi.global.common.entity.BaseEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -28,10 +28,6 @@ public class ChattingParticipant extends BaseEntity {
     @JoinColumn(name = "members_id")
     private Members members;
 
-    @Builder.Default
-    @Enumerated(EnumType.STRING)
-    private ChatStatus status = ChatStatus.ACTIVE;
-
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime joinedAt;
@@ -45,25 +41,11 @@ public class ChattingParticipant extends BaseEntity {
                 .build();
     }
 
-    public void checkSubscriptionStatus() {
-        if (this.status == ChatStatus.INACTIVE) {
-            throw new UnSubscriptionException();
-        }
-    }
-
-    public void subscribe() {
-        this.status = ChatStatus.ACTIVE;
-    }
-
     public void unsubscribe() {
-        this.status = ChatStatus.INACTIVE;
         this.disconnectedAt = LocalDateTime.now();
     }
 
     public void disconnect() {
-        if (this.status == ChatStatus.ACTIVE) {
-            this.status = ChatStatus.INACTIVE;
-            this.disconnectedAt = LocalDateTime.now();
-        }
+        this.disconnectedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/gachtaxi/domain/chat/entity/enums/MessageType.java
+++ b/src/main/java/com/gachtaxi/domain/chat/entity/enums/MessageType.java
@@ -1,5 +1,5 @@
 package com.gachtaxi.domain.chat.entity.enums;
 
 public enum MessageType {
-    MESSAGE, ENTER, EXIT
+    MESSAGE, ENTER, EXIT, READ
 }

--- a/src/main/java/com/gachtaxi/domain/chat/event/WebSocketEventHandler.java
+++ b/src/main/java/com/gachtaxi/domain/chat/event/WebSocketEventHandler.java
@@ -2,8 +2,8 @@ package com.gachtaxi.domain.chat.event;
 
 import com.gachtaxi.domain.chat.entity.ChattingParticipant;
 import com.gachtaxi.domain.chat.exception.ChattingParticipantNotFoundException;
-import com.gachtaxi.domain.chat.service.ChatRedisService;
 import com.gachtaxi.domain.chat.service.ChattingParticipantService;
+import com.gachtaxi.domain.chat.service.ChattingRedisService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -22,7 +22,7 @@ import static com.gachtaxi.domain.chat.stomp.strategy.StompSubscribeStrategy.CHA
 public class WebSocketEventHandler {
 
     private final ChattingParticipantService chattingParticipantService;
-    private final ChatRedisService chatRedisService;
+    private final ChattingRedisService chattingRedisService;
 
     @EventListener
     @Transactional
@@ -35,9 +35,9 @@ public class WebSocketEventHandler {
 
             ChattingParticipant chattingParticipant = chattingParticipantService.find(roomId, userId);
 
-            if (chatRedisService.isActive(roomId, userId)) {
+            if (chattingRedisService.isActive(roomId, userId)) {
                 chattingParticipant.disconnect();
-                chatRedisService.removeSubscribeMember(roomId, userId);
+                chattingRedisService.removeSubscribeMember(roomId, userId);
             }
         } catch (NullPointerException e) {
             log.info("[handleDisconnect] 구독 정보가 존재하지 않습니다.");
@@ -57,9 +57,9 @@ public class WebSocketEventHandler {
         try {
             ChattingParticipant chattingParticipant = chattingParticipantService.find(roomId, userId);
 
-            if (chatRedisService.isActive(roomId, userId)) {
+            if (chattingRedisService.isActive(roomId, userId)) {
                 chattingParticipant.unsubscribe();
-                chatRedisService.removeSubscribeMember(roomId, userId);
+                chattingRedisService.removeSubscribeMember(roomId, userId);
             }
         } catch (ChattingParticipantNotFoundException e) {
             log.warn("[handleUnsubscribe] 이미 퇴장한 참여자 입니다.");

--- a/src/main/java/com/gachtaxi/domain/chat/event/WebSocketEventHandler.java
+++ b/src/main/java/com/gachtaxi/domain/chat/event/WebSocketEventHandler.java
@@ -2,6 +2,7 @@ package com.gachtaxi.domain.chat.event;
 
 import com.gachtaxi.domain.chat.entity.ChattingParticipant;
 import com.gachtaxi.domain.chat.exception.ChattingParticipantNotFoundException;
+import com.gachtaxi.domain.chat.service.ChatRedisService;
 import com.gachtaxi.domain.chat.service.ChattingParticipantService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +22,7 @@ import static com.gachtaxi.domain.chat.stomp.strategy.StompSubscribeStrategy.CHA
 public class WebSocketEventHandler {
 
     private final ChattingParticipantService chattingParticipantService;
+    private final ChatRedisService chatRedisService;
 
     @EventListener
     @Transactional
@@ -33,7 +35,10 @@ public class WebSocketEventHandler {
 
             ChattingParticipant chattingParticipant = chattingParticipantService.find(roomId, userId);
 
-            chattingParticipant.disconnect();
+            if (chatRedisService.isActive(roomId, userId)) {
+                chattingParticipant.disconnect();
+                chatRedisService.removeSubscribeMember(roomId, userId);
+            }
         } catch (NullPointerException e) {
             log.info("[handleDisconnect] 구독 정보가 존재하지 않습니다.");
         } catch (ChattingParticipantNotFoundException e) {
@@ -52,7 +57,10 @@ public class WebSocketEventHandler {
         try {
             ChattingParticipant chattingParticipant = chattingParticipantService.find(roomId, userId);
 
-            chattingParticipant.unsubscribe();
+            if (chatRedisService.isActive(roomId, userId)) {
+                chattingParticipant.unsubscribe();
+                chatRedisService.removeSubscribeMember(roomId, userId);
+            }
         } catch (ChattingParticipantNotFoundException e) {
             log.warn("[handleUnsubscribe] 이미 퇴장한 참여자 입니다.");
         }

--- a/src/main/java/com/gachtaxi/domain/chat/repository/ChattingParticipantRepository.java
+++ b/src/main/java/com/gachtaxi/domain/chat/repository/ChattingParticipantRepository.java
@@ -12,4 +12,6 @@ public interface ChattingParticipantRepository extends JpaRepository<ChattingPar
     Optional<ChattingParticipant> findByChattingRoomAndMembers(ChattingRoom chattingRoom, Members member);
 
     Optional<ChattingParticipant> findByChattingRoomIdAndMembersId(long roomId, long memberId);
+
+    long countByChattingRoomId(long chattingRoomId);
 }

--- a/src/main/java/com/gachtaxi/domain/chat/service/ChatRedisService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChatRedisService.java
@@ -1,5 +1,6 @@
 package com.gachtaxi.domain.chat.service;
 
+import com.gachtaxi.domain.chat.exception.ChattingRoomNotFoundException;
 import com.gachtaxi.domain.chat.exception.UnSubscriptionException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -13,19 +14,19 @@ public class ChatRedisService {
     private final RedisTemplate<String, Object> chatRoomRedisTemplate;
 
     public void saveSubscribeMember(long roomId, long senderId) {
-        String key = REDIS_CHAT_KEY_PREFIX + roomId;
+        String key = getKey(roomId);
 
         chatRoomRedisTemplate.opsForSet().add(key, senderId);
     }
 
     public boolean isActive(long roomId, long senderId) {
-        String key = REDIS_CHAT_KEY_PREFIX + roomId;
+        String key = getKey(roomId);
 
         return Boolean.TRUE.equals(chatRoomRedisTemplate.opsForSet().isMember(key, senderId));
     }
 
     public void removeSubscribeMember(long roomId, long senderId) {
-        String key = REDIS_CHAT_KEY_PREFIX + roomId;
+        String key = getKey(roomId);
 
         chatRoomRedisTemplate.opsForSet().remove(key, senderId);
     }
@@ -34,5 +35,21 @@ public class ChatRedisService {
         if (!isActive(roomId, senderId)) {
             throw new UnSubscriptionException();
         }
+    }
+
+    public long getSubscriberCount(long roomId) {
+        String key = getKey(roomId);
+
+        Long size = chatRoomRedisTemplate.opsForSet().size(key);
+
+        if (size == null) {
+            throw new ChattingRoomNotFoundException();
+        }
+
+        return size;
+    }
+
+    private String getKey(long roomId) {
+        return REDIS_CHAT_KEY_PREFIX + roomId;
     }
 }

--- a/src/main/java/com/gachtaxi/domain/chat/service/ChatRedisService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChatRedisService.java
@@ -1,0 +1,38 @@
+package com.gachtaxi.domain.chat.service;
+
+import com.gachtaxi.domain.chat.exception.UnSubscriptionException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRedisService {
+    public static final String REDIS_CHAT_KEY_PREFIX = "ROOM:";
+
+    private final RedisTemplate<String, Object> chatRoomRedisTemplate;
+
+    public void saveSubscribeMember(long roomId, long senderId) {
+        String key = REDIS_CHAT_KEY_PREFIX + roomId;
+
+        chatRoomRedisTemplate.opsForSet().add(key, senderId);
+    }
+
+    public boolean isActive(long roomId, long senderId) {
+        String key = REDIS_CHAT_KEY_PREFIX + roomId;
+
+        return Boolean.TRUE.equals(chatRoomRedisTemplate.opsForSet().isMember(key, senderId));
+    }
+
+    public void removeSubscribeMember(long roomId, long senderId) {
+        String key = REDIS_CHAT_KEY_PREFIX + roomId;
+
+        chatRoomRedisTemplate.opsForSet().remove(key, senderId);
+    }
+
+    public void checkSubscriptionStatus(long roomId, long senderId) {
+        if (!isActive(roomId, senderId)) {
+            throw new UnSubscriptionException();
+        }
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/chat/service/ChattingParticipantService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChattingParticipantService.java
@@ -1,22 +1,43 @@
 package com.gachtaxi.domain.chat.service;
 
+import com.gachtaxi.domain.chat.dto.request.ChatMessage;
+import com.gachtaxi.domain.chat.dto.response.ReadMessageRange;
+import com.gachtaxi.domain.chat.entity.ChattingMessage;
 import com.gachtaxi.domain.chat.entity.ChattingParticipant;
 import com.gachtaxi.domain.chat.entity.ChattingRoom;
+import com.gachtaxi.domain.chat.entity.enums.MessageType;
 import com.gachtaxi.domain.chat.exception.ChattingParticipantNotFoundException;
 import com.gachtaxi.domain.chat.exception.DuplicateSubscribeException;
+import com.gachtaxi.domain.chat.redis.RedisChatPublisher;
 import com.gachtaxi.domain.chat.repository.ChattingParticipantRepository;
 import com.gachtaxi.domain.members.entity.Members;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChattingParticipantService {
 
     private final ChattingParticipantRepository chattingParticipantRepository;
     private final ChatRedisService chatRedisService;
+    private final MongoTemplate mongoTemplate;
+    private final RedisChatPublisher redisChatPublisher;
+
+    @Value("${chat.topic}")
+    public String chatTopic;
 
     public void save(ChattingParticipant chattingParticipant) {
         chattingParticipantRepository.save(chattingParticipant);
@@ -39,7 +60,14 @@ public class ChattingParticipantService {
             ChattingParticipant chattingParticipant = optionalParticipant.get();
 
             checkDuplicateSubscription(chattingRoom.getId(), members.getId());
-            chatRedisService.saveSubscribeMember(chattingRoom.getId(), members.getId());
+
+            updateUnreadCount(chattingRoom.getId(), chattingParticipant.getLastReadAt(), members.getId());
+
+            Pair<String, String> pair = getUpdatedMessageRange(chattingRoom.getId(), chattingParticipant.getLastReadAt(), members.getId());
+
+            reEnterEvent(chattingRoom.getId(), members.getId(), members.getNickname(), ReadMessageRange.of(pair));
+
+            chattingParticipant.reSubscribe();
 
             return true;
         }
@@ -51,9 +79,58 @@ public class ChattingParticipantService {
         chattingParticipantRepository.delete(chattingParticipant);
     }
 
+    public long getParticipantCount(Long roomId) {
+        return chattingParticipantRepository.countByChattingRoomId(roomId);
+    }
+
     private void checkDuplicateSubscription(long roomId, long memberId) {
         if (chatRedisService.isActive(roomId, memberId)) {
+            log.info("memberId {}", memberId);
             throw new DuplicateSubscribeException();
         }
+    }
+
+    public void updateUnreadCount(Long roomId, LocalDateTime lastReadAt, Long senderId) {
+        Query query = new Query().addCriteria(
+                Criteria.where("roomId").is(roomId)
+                        .and("timeStamp").gt(lastReadAt)
+                        .and("senderId").ne(senderId)
+                        .and("unreadCount").gt(0)
+        );
+
+        Update update = new Update().inc("unreadCount", -1);
+
+        mongoTemplate.updateMulti(query, update, ChattingMessage.class);
+    }
+
+    public Pair<String, String> getUpdatedMessageRange(Long roomId, LocalDateTime lastReadAt, Long senderId) {
+        Query minQuery = new Query().addCriteria(
+                Criteria.where("roomId").is(roomId)
+                        .and("timeStamp").gt(lastReadAt)
+                        .and("senderId").ne(senderId)
+                        .and("unreadCount").gt(0)
+        ).with(Sort.by(Sort.Direction.ASC, "_id")).limit(1);
+
+        Query maxQuery = new Query().addCriteria(
+                Criteria.where("roomId").is(roomId)
+                        .and("timeStamp").gt(lastReadAt)
+                        .and("senderId").ne(senderId)
+                        .and("unreadCount").gt(0)
+        ).with(Sort.by(Sort.Direction.DESC, "_id")).limit(1);
+
+        ChattingMessage minMessage = mongoTemplate.findOne(minQuery, ChattingMessage.class, "chatting_messages");
+        ChattingMessage maxMessage = mongoTemplate.findOne(maxQuery, ChattingMessage.class, "chatting_messages");
+
+        String minId = (minMessage != null) ? minMessage.getId() : "NO_MESSAGES";
+        String maxId = (maxMessage != null) ? maxMessage.getId() : "NO_MESSAGES";
+
+        return Pair.of(minId, maxId);
+    }
+
+    private void reEnterEvent(long roomId, long senderId, String senderName, ReadMessageRange range) {
+        ChannelTopic topic = new ChannelTopic(chatTopic + roomId);
+        ChatMessage chatMessage = ChatMessage.of(roomId, senderId, senderName, range, MessageType.READ);
+
+        redisChatPublisher.publish(topic, chatMessage);
     }
 }

--- a/src/main/java/com/gachtaxi/domain/chat/service/ChattingParticipantService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChattingParticipantService.java
@@ -12,7 +12,6 @@ import com.gachtaxi.domain.chat.redis.RedisChatPublisher;
 import com.gachtaxi.domain.chat.repository.ChattingParticipantRepository;
 import com.gachtaxi.domain.members.entity.Members;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -26,13 +25,12 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChattingParticipantService {
 
     private final ChattingParticipantRepository chattingParticipantRepository;
-    private final ChatRedisService chatRedisService;
+    private final ChattingRedisService chattingRedisService;
     private final MongoTemplate mongoTemplate;
     private final RedisChatPublisher redisChatPublisher;
 
@@ -84,8 +82,7 @@ public class ChattingParticipantService {
     }
 
     private void checkDuplicateSubscription(long roomId, long memberId) {
-        if (chatRedisService.isActive(roomId, memberId)) {
-            log.info("memberId {}", memberId);
+        if (chattingRedisService.isActive(roomId, memberId)) {
             throw new DuplicateSubscribeException();
         }
     }

--- a/src/main/java/com/gachtaxi/domain/chat/service/ChattingParticipantService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChattingParticipantService.java
@@ -63,7 +63,7 @@ public class ChattingParticipantService {
 
             Pair<String, String> pair = getUpdatedMessageRange(chattingRoom.getId(), chattingParticipant.getLastReadAt(), members.getId());
 
-            reEnterEvent(chattingRoom.getId(), members.getId(), members.getNickname(), ReadMessageRange.of(pair));
+            reEnterEvent(chattingRoom.getId(), members.getId(), members.getNickname(), ReadMessageRange.from(pair));
 
             chattingParticipant.reSubscribe();
 

--- a/src/main/java/com/gachtaxi/domain/chat/service/ChattingRedisService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChattingRedisService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class ChatRedisService {
+public class ChattingRedisService {
     public static final String REDIS_CHAT_KEY_PREFIX = "ROOM:";
 
     private final RedisTemplate<String, Object> chatRoomRedisTemplate;

--- a/src/main/java/com/gachtaxi/domain/chat/service/ChattingRoomService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChattingRoomService.java
@@ -36,7 +36,7 @@ public class ChattingRoomService {
     private final ChattingParticipantService chattingParticipantService;
     private final MemberService memberService;
     private final RedisChatPublisher redisChatPublisher;
-    private final ChatRedisService chatRedisService;
+    private final ChattingRedisService chattingRedisService;
 
     @Value("${chat.topic}")
     public String chatTopic;
@@ -67,12 +67,12 @@ public class ChattingRoomService {
         accessor.getSessionAttributes().put(CHAT_USER_NAME, members.getNickname());
 
         if (chattingParticipantService.checkSubscription(chattingRoom, members)) {
-            chatRedisService.saveSubscribeMember(chattingRoom.getId(), members.getId());
+            chattingRedisService.saveSubscribeMember(chattingRoom.getId(), members.getId());
 
             return;
         }
 
-        chatRedisService.saveSubscribeMember(chattingRoom.getId(), members.getId());
+        chattingRedisService.saveSubscribeMember(chattingRoom.getId(), members.getId());
 
         ChattingParticipant newParticipant = ChattingParticipant.of(chattingRoom, members);
         chattingParticipantService.save(newParticipant);

--- a/src/main/java/com/gachtaxi/domain/chat/service/ChattingRoomService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChattingRoomService.java
@@ -5,8 +5,8 @@ import com.gachtaxi.domain.chat.dto.response.ChattingRoomResponse;
 import com.gachtaxi.domain.chat.entity.ChattingMessage;
 import com.gachtaxi.domain.chat.entity.ChattingParticipant;
 import com.gachtaxi.domain.chat.entity.ChattingRoom;
-import com.gachtaxi.domain.chat.entity.enums.MessageType;
 import com.gachtaxi.domain.chat.entity.enums.ChatStatus;
+import com.gachtaxi.domain.chat.entity.enums.MessageType;
 import com.gachtaxi.domain.chat.exception.ChattingRoomNotFoundException;
 import com.gachtaxi.domain.chat.redis.RedisChatPublisher;
 import com.gachtaxi.domain.chat.repository.ChattingMessageRepository;
@@ -31,12 +31,12 @@ public class ChattingRoomService {
     private static final String ENTER_MESSAGE =" 님이 입장하셨습니다.";
     private static final String EXIT_MESSAGE =" 님이 퇴장하셨습니다.";
 
-
     private final ChattingRoomRepository chattingRoomRepository;
     private final ChattingMessageRepository chattingMessageRepository;
     private final ChattingParticipantService chattingParticipantService;
     private final MemberService memberService;
     private final RedisChatPublisher redisChatPublisher;
+    private final ChatRedisService chatRedisService;
 
     @Value("${chat.topic}")
     public String chatTopic;
@@ -67,8 +67,12 @@ public class ChattingRoomService {
         accessor.getSessionAttributes().put(CHAT_USER_NAME, members.getNickname());
 
         if (chattingParticipantService.checkSubscription(chattingRoom, members)) {
+            chatRedisService.saveSubscribeMember(chattingRoom.getId(), members.getId());
+
             return;
         }
+
+        chatRedisService.saveSubscribeMember(chattingRoom.getId(), members.getId());
 
         ChattingParticipant newParticipant = ChattingParticipant.of(chattingRoom, members);
         chattingParticipantService.save(newParticipant);
@@ -94,13 +98,14 @@ public class ChattingRoomService {
     }
 
     private void publishMessage(long roomId, long senderId, String senderName, String message, MessageType messageType) {
-        ChannelTopic topic = new ChannelTopic(chatTopic + roomId);
-        ChatMessage chatMessage = ChatMessage.of(roomId, senderId, senderName, senderName + message, messageType);
-        ChattingMessage chattingMessage = ChattingMessage.from(chatMessage);
+        ChattingMessage chattingMessage = ChattingMessage.of(roomId, senderId, senderName, senderName + message, messageType);
 
         chattingMessageRepository.save(chattingMessage);
+
+        ChannelTopic topic = new ChannelTopic(chatTopic + roomId);
+        ChatMessage chatMessage = ChatMessage.from(chattingMessage);
+
         redisChatPublisher.publish(topic, chatMessage);
     }
-
 
 }

--- a/src/main/java/com/gachtaxi/domain/chat/service/ChattingService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChattingService.java
@@ -40,6 +40,7 @@ public class ChattingService {
     private final ChattingRoomService chattingRoomService;
     private final ChattingParticipantService chattingParticipantService;
     private final MemberService memberService;
+    private final ChatRedisService chatRedisService;
 
     @Value("${chat.topic}")
     public String chatTopic;
@@ -62,7 +63,7 @@ public class ChattingService {
         Members members = memberService.findById(senderId);
         ChattingParticipant chattingParticipant = chattingParticipantService.find(chattingRoom, members);
 
-        chattingParticipant.checkSubscriptionStatus();
+        chatRedisService.checkSubscriptionStatus(roomId, senderId);
 
         Slice<ChattingMessage> chattingMessages = loadMessage(roomId, chattingParticipant, pageNumber, pageSize, lastMessageTimeStamp);
 

--- a/src/main/java/com/gachtaxi/domain/chat/service/ChattingService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChattingService.java
@@ -41,7 +41,7 @@ public class ChattingService {
     private final ChattingRoomService chattingRoomService;
     private final ChattingParticipantService chattingParticipantService;
     private final MemberService memberService;
-    private final ChatRedisService chatRedisService;
+    private final ChattingRedisService chattingRedisService;
 
     @Value("${chat.topic}")
     public String chatTopic;
@@ -72,7 +72,7 @@ public class ChattingService {
         Members members = memberService.findById(senderId);
         ChattingParticipant chattingParticipant = chattingParticipantService.find(chattingRoom, members);
 
-        chatRedisService.checkSubscriptionStatus(roomId, senderId);
+        chattingRedisService.checkSubscriptionStatus(roomId, senderId);
 
         Slice<ChattingMessage> chattingMessages = loadMessage(roomId, chattingParticipant, pageNumber, pageSize, lastMessageTimeStamp);
 
@@ -115,7 +115,7 @@ public class ChattingService {
 
     private long getUnreadCount(long roomId) {
         long totalCount = chattingParticipantService.getParticipantCount(roomId);
-        long nowCount = chatRedisService.getSubscriberCount(roomId);
+        long nowCount = chattingRedisService.getSubscriberCount(roomId);
 
         return totalCount - nowCount;
     }

--- a/src/main/java/com/gachtaxi/global/config/MongoConfig.java
+++ b/src/main/java/com/gachtaxi/global/config/MongoConfig.java
@@ -1,0 +1,19 @@
+package com.gachtaxi.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+
+@Configuration
+public class MongoConfig {
+
+    @Value("${spring.kafka.mongodb.uri}")
+    private String mongoUri;
+
+    @Bean
+    public MongoTemplate mongoTemplate() {
+        return new MongoTemplate(new SimpleMongoClientDatabaseFactory(mongoUri));
+    }
+}

--- a/src/main/java/com/gachtaxi/global/config/RedisConfig.java
+++ b/src/main/java/com/gachtaxi/global/config/RedisConfig.java
@@ -14,6 +14,7 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -76,13 +77,13 @@ public class RedisConfig {
         return container;
     }
 
-    // @Bean
-    // @Qualifier("jwtRedisTemplate")
-    // public RedisTemplate<String, String> jwtRedisTemplate(RedisConnectionFactory factory) {
-    //     RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
-    //     redisTemplate.setConnectionFactory(factory);
-    //     redisTemplate.setKeySerializer(new StringRedisSerializer());
-    //     redisTemplate.setValueSerializer(new StringRedisSerializer());
-    //     return redisTemplate;
-    // }
+     @Bean
+     @Qualifier("chatRoomRedisTemplate")
+     public RedisTemplate<String, Object> chatRoomRedisTemplate(RedisConnectionFactory factory) {
+         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+         redisTemplate.setConnectionFactory(factory);
+         redisTemplate.setKeySerializer(new StringRedisSerializer());
+         redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+         return redisTemplate;
+     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #40 
Close #


## 🚀 작업 내용
- 채팅방에서 읽음 처리 및 읽지 않은 사람 수를 계산해 메시지를 발행하는 로직을 구현했습니다
- redis에 실시간 참여자를 저장해 메시지 전송시 동적으로 전체 참여자 - 현재 참여자를 계산해 unreadCount로 반환하도록 구현했습니다
- chattingParticipant 엔티티에 연결 해제시간 -> 마지막 채팅 읽은 시간으로 변경해  재 입장시 마지막 읽은 시간 이후 메시지(내가 보내지 않은)에 대한 읽음 처리를 원자적으로 진행할 수 있게 구현했습니다
- 미지막 읽은 시간은 1. 재입장시 읽음 처리 이후 업데이트 2. 채팅방을 나갈 때 업데이트 하도록 했습니다
- 채팅방에  참여자가 있는 상황에서 누군가 들어와 읽음 처리가 된다면 실시간으로 숫자가 변동이 되어야합니다. 따라서 클라이언트에게 현재 읽음 처리가 된 메시지 범위를 전달해 사용자가 해당 메시지 범위 안에 드는 화면을 보고 있다면 실시간으로 -1을 할 수 있도록 웹소켓 이벤트 처리를 진행했습니다
- 몽고 db의 objectId의 경우는 패턴이 있어 대소 비교가 가능하기 때문에 해당 특성을 이용했습니다


## 📸 스크린샷
- 재입장시 읽음 이벤트가 발행되는 모습
<img width="1020" alt="image" src="https://github.com/user-attachments/assets/73289d46-5835-4061-81e2-0d682d069c2d" />

- 2명이 참여하고 있을 때 메시지 전송 시 unreadCount가 감소한 모습
<img width="954" alt="image" src="https://github.com/user-attachments/assets/6c65718a-7811-49af-a630-b7313e952074" />

## 📢 리뷰 요구사항
- 서비스간 책임 분리가 모호해져서 다음 작업에서 리팩토링할 계획입니다.
- 기본 MongoRepository로는 커스텀 쿼리 작성이 어려워서 MongoTemplate을 사용했습니다. 해당 빈을 주입하니 채팅 메시지가 저장될 때 디폴트 db에 저장되는 현상이 발견돼서 MongoConfig 클래스를 추가했습니다
- 해당 방식 말고도 동일한 쿼리 처리가 가능한 방법이 있다면 알려주시면 수정하겠습니다
