### PR TITLE
Fix #50 유저 정보 응답 수정

### DIFF
--- a/src/main/java/com/gachtaxi/domain/members/controller/AuthController.java
+++ b/src/main/java/com/gachtaxi/domain/members/controller/AuthController.java
@@ -3,6 +3,10 @@ package com.gachtaxi.domain.members.controller;
 import com.gachtaxi.domain.members.dto.request.InactiveMemberAuthCodeRequestDto;
 import com.gachtaxi.domain.members.dto.request.MemberAgreementRequestDto;
 import com.gachtaxi.domain.members.dto.request.MemberSupplmentRequestDto;
+import com.gachtaxi.domain.members.dto.request.MemberTokenDto;
+import com.gachtaxi.domain.members.dto.response.LoginDto;
+import com.gachtaxi.domain.members.dto.response.MemberLoginResponseDto;
+import com.gachtaxi.domain.members.dto.response.MemberResponseDto;
 import com.gachtaxi.domain.members.service.AuthService;
 import com.gachtaxi.domain.members.service.MemberService;
 import com.gachtaxi.global.auth.google.dto.GoogleAuthCode;
@@ -40,37 +44,44 @@ public class AuthController {
 
     @PostMapping("/login/kakao")
     @Operation(summary = "인가 코드를 전달받아, 카카오 소셜 로그인을 진행합니다.")
-    public ApiResponse<ResponseMessage> kakaoLogin(
+    public ApiResponse<MemberLoginResponseDto> kakaoLogin(
             @RequestBody @Valid KakaoAuthCode kakaoAuthCode
             , HttpServletResponse response)
     {
-        JwtTokenDto jwtTokenDto = authService.kakaoLogin(kakaoAuthCode.authCode());
-        response.setHeader(ACCESS_TOKEN_SUBJECT, jwtTokenDto.accessToken());
+        LoginDto loginDto = authService.kakaoLogin(kakaoAuthCode.authCode());
+        response.setHeader(ACCESS_TOKEN_SUBJECT, loginDto.jwtTokenDto().accessToken());
 
-        if (jwtTokenDto.isTemporaryUser()) { // 임시 유저
-            return ApiResponse.response(OK, UN_REGISTER.getMessage(), UN_REGISTER);
+        if (loginDto.isTemporaryUser()) { // 임시 유저
+            return ApiResponse.response(OK, UN_REGISTER.getMessage(), MemberLoginResponseDto.from());
         }
 
-        cookieUtil.setCookie(REFRESH_TOKEN_SUBJECT, jwtTokenDto.refreshToken(), response);
-        return ApiResponse.response(OK, LOGIN_SUCCESS.getMessage(), LOGIN_SUCCESS);
+        cookieUtil.setCookie(REFRESH_TOKEN_SUBJECT, loginDto.jwtTokenDto().refreshToken(), response);
+        return ApiResponse.response(
+                OK,
+                LOGIN_SUCCESS.getMessage(),
+                MemberLoginResponseDto.from(loginDto.memberResponseDto())
+        );
     }
 
     @PostMapping("/login/google")
     @Operation(summary = "인가 코드를 전달받아, 구글 소셜 로그인을 진행합니다.")
-    public ApiResponse<ResponseMessage> googleLogin(
+    public ApiResponse<MemberLoginResponseDto> googleLogin(
             @RequestBody @Valid GoogleAuthCode googleAuthCode
             , HttpServletResponse response)
     {
-        JwtTokenDto jwtTokenDto = authService.googleLogin(googleAuthCode.authCode());
-        response.setHeader(ACCESS_TOKEN_SUBJECT, jwtTokenDto.accessToken());
+        LoginDto loginDto = authService.googleLogin(googleAuthCode.authCode());
+        response.setHeader(ACCESS_TOKEN_SUBJECT, loginDto.jwtTokenDto().accessToken());
 
-        if (jwtTokenDto.isTemporaryUser()) { // 임시 유저
-            return ApiResponse.response(HttpStatus.OK, UN_REGISTER.getMessage(), UN_REGISTER);
+        if (loginDto.isTemporaryUser()) { // 임시 유저
+            return ApiResponse.response(HttpStatus.OK, UN_REGISTER.getMessage(), MemberLoginResponseDto.from());
         }
 
-        cookieUtil.setCookie(REFRESH_TOKEN_SUBJECT, jwtTokenDto.refreshToken(), response);
-        return ApiResponse.response(OK, LOGIN_SUCCESS.getMessage(), LOGIN_SUCCESS);
-    }
+        cookieUtil.setCookie(REFRESH_TOKEN_SUBJECT, loginDto.jwtTokenDto().refreshToken(), response);
+        return ApiResponse.response(
+                OK,
+                LOGIN_SUCCESS.getMessage(),
+                MemberLoginResponseDto.from(loginDto.memberResponseDto())
+        );    }
 
     @PostMapping("/refresh")
     @Operation(summary = "RefreshToken으로 AccessToken과 RefreshToken을 재발급 하는 API 입니다.")
@@ -122,16 +133,21 @@ public class AuthController {
 
     @PatchMapping("/supplement")
     @Operation(summary = "사용자 추가 정보 업데이트하는 API 입니다. (프로필, 닉네임, 실명, 학번, 성별,)")
-    public ApiResponse<Void> updateMemberSupplement(
+    public ApiResponse<MemberLoginResponseDto> updateMemberSupplement(
             @RequestBody MemberSupplmentRequestDto dto,
             @CurrentMemberId Long userId,
             HttpServletResponse response
     ){
+        MemberResponseDto memberDto = memberService.updateMemberSupplement(dto, userId);
         JwtTokenDto jwtTokenDto = jwtService
-                .generateJwtToken(memberService.updateMemberSupplement(dto, userId));
+                .generateJwtToken(MemberTokenDto.from(memberDto));
         responseToken(jwtTokenDto, response);
 
-        return ApiResponse.response(OK, SUPPLEMENT_UPDATE_SUCCESS.getMessage());
+        return ApiResponse.response(
+                OK,
+                SUPPLEMENT_UPDATE_SUCCESS.getMessage(),
+                MemberLoginResponseDto.from(memberDto)
+        );
     }
 
     /*

--- a/src/main/java/com/gachtaxi/domain/members/dto/request/MemberTokenDto.java
+++ b/src/main/java/com/gachtaxi/domain/members/dto/request/MemberTokenDto.java
@@ -1,5 +1,6 @@
 package com.gachtaxi.domain.members.dto.request;
 
+import com.gachtaxi.domain.members.dto.response.MemberResponseDto;
 import com.gachtaxi.domain.members.entity.Members;
 import lombok.Builder;
 
@@ -22,6 +23,14 @@ public record MemberTokenDto(
                 .id(id)
                 .email(email)
                 .role(role)
+                .build();
+    }
+
+    public static MemberTokenDto from(MemberResponseDto dto){
+        return MemberTokenDto.builder()
+                .id(dto.userId())
+                .email(dto.email())
+                .role(dto.role())
                 .build();
     }
 }

--- a/src/main/java/com/gachtaxi/domain/members/dto/response/LoginDto.java
+++ b/src/main/java/com/gachtaxi/domain/members/dto/response/LoginDto.java
@@ -1,0 +1,27 @@
+package com.gachtaxi.domain.members.dto.response;
+
+import com.gachtaxi.global.auth.jwt.dto.JwtTokenDto;
+import lombok.Builder;
+
+@Builder
+public record LoginDto(
+        JwtTokenDto jwtTokenDto,
+        MemberResponseDto memberResponseDto
+) {
+    public static LoginDto of(JwtTokenDto jwtTokenDto, MemberResponseDto memberResponseDto) {
+        return LoginDto.builder()
+                .jwtTokenDto(jwtTokenDto)
+                .memberResponseDto(memberResponseDto)
+                .build();
+    }
+
+    public static LoginDto from(JwtTokenDto jwtTokenDto) {
+        return LoginDto.builder()
+                .jwtTokenDto(jwtTokenDto)
+                .build();
+    }
+
+    public boolean isTemporaryUser(){
+        return this.memberResponseDto == null;
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/members/dto/response/MemberLoginResponseDto.java
+++ b/src/main/java/com/gachtaxi/domain/members/dto/response/MemberLoginResponseDto.java
@@ -1,0 +1,24 @@
+package com.gachtaxi.domain.members.dto.response;
+
+import lombok.Builder;
+
+import static com.gachtaxi.domain.members.controller.ResponseMessage.*;
+
+@Builder
+public record MemberLoginResponseDto(
+        String status,
+        MemberResponseDto memberResponseDto
+) {
+    public static MemberLoginResponseDto from(MemberResponseDto memberResponseDto) {
+        return MemberLoginResponseDto.builder()
+                .status(LOGIN_SUCCESS.name())
+                .memberResponseDto(memberResponseDto)
+                .build();
+    }
+
+    public static MemberLoginResponseDto from() {
+        return MemberLoginResponseDto.builder()
+                .status(UN_REGISTER.name())
+                .build();
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/members/dto/response/MemberResponseDto.java
+++ b/src/main/java/com/gachtaxi/domain/members/dto/response/MemberResponseDto.java
@@ -1,0 +1,30 @@
+package com.gachtaxi.domain.members.dto.response;
+
+import com.gachtaxi.domain.members.entity.Members;
+import com.gachtaxi.domain.members.entity.enums.Gender;
+import lombok.Builder;
+
+@Builder
+public record MemberResponseDto(
+        Long userId,
+        Long studentNumber,
+        String nickName,
+        String realName,
+        String profilePicture,
+        String email,
+        String role,
+        Gender gender
+) {
+    public static MemberResponseDto from(Members members) {
+        return MemberResponseDto.builder()
+                .userId(members.getId())
+                .studentNumber(members.getStudentNumber())
+                .nickName(members.getNickname())
+                .realName(members.getRealName())
+                .profilePicture(members.getProfilePicture())
+                .email(members.getEmail())
+                .role(members.getRole().name())
+                .gender(members.getGender())
+                .build();
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/members/service/AuthService.java
+++ b/src/main/java/com/gachtaxi/domain/members/service/AuthService.java
@@ -2,11 +2,12 @@ package com.gachtaxi.domain.members.service;
 
 import com.gachtaxi.domain.members.dto.request.InactiveMemberDto;
 import com.gachtaxi.domain.members.dto.request.MemberTokenDto;
+import com.gachtaxi.domain.members.dto.response.LoginDto;
+import com.gachtaxi.domain.members.dto.response.MemberResponseDto;
 import com.gachtaxi.domain.members.entity.Members;
 import com.gachtaxi.global.auth.google.dto.GoogleTokenResponse;
 import com.gachtaxi.global.auth.google.dto.GoogleUserInfoResponse;
 import com.gachtaxi.global.auth.google.utils.GoogleUtils;
-import com.gachtaxi.global.auth.jwt.dto.JwtTokenDto;
 import com.gachtaxi.global.auth.jwt.service.JwtService;
 import com.gachtaxi.global.auth.kakao.util.KakaoUtil;
 import lombok.RequiredArgsConstructor;
@@ -27,38 +28,52 @@ public class AuthService {
     private final JwtService jwtService;
     private final MemberService memberService;
 
-    public JwtTokenDto kakaoLogin(String authCode) {
+    public LoginDto kakaoLogin(String authCode) {
         KakaoUserInfoResponse userInfo = getKakaoUserInfoResponse(authCode);
         Long kakaoId = userInfo.id();
 
         Optional<Members> optionalMember = memberService.findByKakaoId(kakaoId);
         if(optionalMember.isEmpty()) {
-            return jwtService.generateTmpAccessToken(memberService.saveTmpKakaoMember(kakaoId));
+            return LoginDto.from(
+                    jwtService.generateTmpAccessToken(memberService.saveTmpKakaoMember(kakaoId))
+            );
         }
 
         Members members = optionalMember.get();
         if(members.getStatus() == INACTIVE){
-            return jwtService.generateTmpAccessToken(InactiveMemberDto.of(optionalMember.get()));
+            return LoginDto.from(
+                    jwtService.generateTmpAccessToken(InactiveMemberDto.of(optionalMember.get()))
+            );
         }
 
-        return jwtService.generateJwtToken(MemberTokenDto.from(members));
+        return LoginDto.of(
+                jwtService.generateJwtToken(MemberTokenDto.from(members)),
+                MemberResponseDto.from(members)
+        );
     }
 
-    public JwtTokenDto googleLogin(String authCode) {
+    public LoginDto googleLogin(String authCode) {
         GoogleUserInfoResponse userInfo = getGoogleUserInfoResponse(authCode);
         String googleId = userInfo.id();
 
         Optional<Members> optionalMember = memberService.findByGoogleId(googleId);
         if(optionalMember.isEmpty()) {
-            return jwtService.generateTmpAccessToken(memberService.saveTmpGoogleMember(googleId));
+            return LoginDto.from(
+                    jwtService.generateTmpAccessToken(memberService.saveTmpGoogleMember(googleId))
+            );
         }
 
         Members members = optionalMember.get();
         if(members.getStatus() == INACTIVE){
-            return jwtService.generateTmpAccessToken(InactiveMemberDto.of(optionalMember.get()));
+            return LoginDto.from(
+                    jwtService.generateTmpAccessToken(InactiveMemberDto.of(optionalMember.get()))
+            );
         }
 
-        return jwtService.generateJwtToken(MemberTokenDto.from(members));
+        return LoginDto.of(
+                jwtService.generateJwtToken(MemberTokenDto.from(members)),
+                MemberResponseDto.from(members)
+        );
     }
 
 

--- a/src/main/java/com/gachtaxi/domain/members/service/MemberService.java
+++ b/src/main/java/com/gachtaxi/domain/members/service/MemberService.java
@@ -4,7 +4,7 @@ import com.gachtaxi.domain.members.dto.request.FcmTokenRequest;
 import com.gachtaxi.domain.members.dto.request.InactiveMemberDto;
 import com.gachtaxi.domain.members.dto.request.MemberAgreementRequestDto;
 import com.gachtaxi.domain.members.dto.request.MemberSupplmentRequestDto;
-import com.gachtaxi.domain.members.dto.request.MemberTokenDto;
+import com.gachtaxi.domain.members.dto.response.MemberResponseDto;
 import com.gachtaxi.domain.members.entity.Members;
 import com.gachtaxi.domain.members.exception.DuplicatedNickNameException;
 import com.gachtaxi.domain.members.exception.DuplicatedStudentNumberException;
@@ -51,14 +51,14 @@ public class MemberService {
     }
 
     @Transactional
-    public MemberTokenDto updateMemberSupplement(MemberSupplmentRequestDto dto, Long userId) {
+    public MemberResponseDto updateMemberSupplement(MemberSupplmentRequestDto dto, Long userId) {
         checkDuplicatedNickName(dto.nickname());
         checkDuplicatedStudentNumber(dto.studentNumber());
 
         Members members = findById(userId);
         members.updateSupplment(dto);
 
-        return MemberTokenDto.from(members);
+        return MemberResponseDto.from(members);
     }
 
     public Optional<Members> findByKakaoId(Long kakaoId) {return memberRepository.findByKakaoId(kakaoId);}


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #49 
Close #49 


## 🚀 작업 내용
> PR에서 작업한 내용을 설명
- [ ] 성공적으로 로그인 시 유저 정보 반환
- [ ] 회원가입 최종 완료 시 유저 정보 반환

기존 AuthService에서 소셜 로그인 비지니스 로직을 거칠 때, AccessToken과 RefreshToken을 정보를 가진 JwtTokenDto를 반환했고 이를 컨트롤러 단에서 심어주고 있었습니다.

유저 정보를 추가로 반환해달라는 프론트의 요청이 있어 이를 위해 다음과 같이 변경합니다.
우선 AuthService에서 소셜 로그인 비지니스 로직을 거칠 때 멤버 정보와 JwtToken 정보를 가지는 LoginDto를 반환하도록 했습니다.

```java
public record LoginDto(
        JwtTokenDto jwtTokenDto,
        MemberResponseDto memberResponseDto
) { 
  // 정적 팩토리 메서드
}
```

추가로 3단계의 회원가입 단계 (이메일 인증, 약관 동의, 추가 정보 입력) 中 마지막 단계인 추가 정보 입력에서
요청에 성공적으로 응답할 경우 유저 정보를 함께 반환하도록 수정했습니다.

실제로 프론트측에 응답할 때는 다음과 같은 MemberLoginResponseDto를 응답해
`LOGIN_SUCCESS`, `UN_REGISTER` 이 두가지 상황을 같이 나타낼 수 있도록 했습니다.

```java
public record MemberLoginResponseDto(
        String status,
        MemberResponseDto memberResponseDto
) {
```

## 📸 스크린샷

### 소셜 로그인 성공 시 응답 (최초 회원가입을 진행한 멤버)
![image](https://github.com/user-attachments/assets/b1ef3b01-cc4b-4745-b432-e4b25940b744)

### 소셜 로그인 후 최초 회원 가입을 해야하는 경우 응답
![image](https://github.com/user-attachments/assets/02f8081e-5dda-45e9-bf8e-5cf1fb2db265)

### 최종 회원가입 과정을 성공적으로 수행한 경우 응답
![image](https://github.com/user-attachments/assets/7d2d1eb2-2416-490d-842f-cf0cea51d696)





## 📢 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성

빠르게 구현해서 프론트가 로그인 이후 페이지를 직접 확인할 수 있게 하기 위해서 빠르게 구현했습니다.
추후 시간이 난다면 dto와 메서드별 책임을 다시 생각해 더 나은 코드를작성해보겠습니다.
테스트 상 문제는 없었습니다!

