### PR TITLE
Feat #54 이미지 추가해서 반환

### DIFF
--- a/src/main/java/com/gachtaxi/domain/chat/controller/ChattingController.java
+++ b/src/main/java/com/gachtaxi/domain/chat/controller/ChattingController.java
@@ -2,6 +2,7 @@ package com.gachtaxi.domain.chat.controller;
 
 import com.gachtaxi.domain.chat.dto.request.ChatMessageRequest;
 import com.gachtaxi.domain.chat.dto.response.ChatResponse;
+import com.gachtaxi.domain.chat.dto.response.ChattingRoomCountResponse;
 import com.gachtaxi.domain.chat.dto.response.ChattingRoomResponse;
 import com.gachtaxi.domain.chat.service.ChattingRoomService;
 import com.gachtaxi.domain.chat.service.ChattingService;
@@ -46,6 +47,15 @@ public class ChattingController {
         ChatResponse response = chattingService.getMessage(roomId, memberId, pageNumber, pageSize, lastMessageTimeStamp);
 
         return ApiResponse.response(OK, GET_CHATTING_MESSAGE_SUCCESS.getMessage(), response);
+    }
+
+    @GetMapping("/api/chat/count/{roomId}")
+    @Operation(summary = "채팅방의 총 참여자 수를 조회하기 위한 API입니다.")
+    public ApiResponse<ChattingRoomCountResponse> getChattingMessageCount(@CurrentMemberId Long memberId,
+                                                                          @PathVariable Long roomId) {
+        ChattingRoomCountResponse response = chattingRoomService.getCount(memberId, roomId);
+
+        return ApiResponse.response(OK, GET_CHATTING_PARTICIPANT_COUNT_SUCCESS.getMessage(), response);
     }
 
     @DeleteMapping("/api/chat/{roomId}")

--- a/src/main/java/com/gachtaxi/domain/chat/controller/ResponseMessage.java
+++ b/src/main/java/com/gachtaxi/domain/chat/controller/ResponseMessage.java
@@ -9,7 +9,8 @@ public enum ResponseMessage {
 
     CREATE_CHATTING_ROOM_SUCCESS("채팅방 생성에 성공했습니다."),
     GET_CHATTING_MESSAGE_SUCCESS("이전 메시지 조회에 성공 했습니다."),
-    EXIT_CHATTING_ROOM_SUCCESS("채팅방 퇴장에 성공했습니다.");
+    EXIT_CHATTING_ROOM_SUCCESS("채팅방 퇴장에 성공했습니다."),
+    GET_CHATTING_PARTICIPANT_COUNT_SUCCESS("채팅방 전체 참여자 조회에 성공했습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/gachtaxi/domain/chat/dto/request/ChatMessage.java
+++ b/src/main/java/com/gachtaxi/domain/chat/dto/request/ChatMessage.java
@@ -16,6 +16,7 @@ public record ChatMessage(
         Long senderId,
         String senderName,
         String message,
+        String profilePicture,
         ReadMessageRange range,
         Long unreadCount,
         LocalDateTime timeStamp,
@@ -28,6 +29,7 @@ public record ChatMessage(
                 .senderId(chattingMessage.getSenderId())
                 .senderName(chattingMessage.getSenderName())
                 .message(chattingMessage.getMessage())
+                .profilePicture(chattingMessage.getProfilePicture())
                 .unreadCount(chattingMessage.getUnreadCount())
                 .timeStamp(chattingMessage.getTimeStamp())
                 .messageType(chattingMessage.getMessageType())

--- a/src/main/java/com/gachtaxi/domain/chat/dto/response/ChatResponse.java
+++ b/src/main/java/com/gachtaxi/domain/chat/dto/response/ChatResponse.java
@@ -16,7 +16,7 @@ public record ChatResponse(
     public static ChatResponse of(ChattingParticipant chattingParticipant, List<ChattingMessageResponse> chattingMessages, ChatPageableResponse chatPageableResponse) {
         return ChatResponse.builder()
                 .memberId(chattingParticipant.getMembers().getId())
-                .disconnectedAt(chattingParticipant.getLastReadAt())
+                .disconnectedAt(chattingParticipant.getDisconnectedAt())
                 .chattingMessage(chattingMessages)
                 .pageable(chatPageableResponse)
                 .build();

--- a/src/main/java/com/gachtaxi/domain/chat/dto/response/ChattingMessageResponse.java
+++ b/src/main/java/com/gachtaxi/domain/chat/dto/response/ChattingMessageResponse.java
@@ -12,6 +12,7 @@ public record ChattingMessageResponse(
         Long senderId,
         String senderName,
         String message,
+        String profilePicture,
         Long unreadCount,
         LocalDateTime timeStamp,
         MessageType messageType
@@ -22,6 +23,7 @@ public record ChattingMessageResponse(
                 .senderId(chattingMessage.getSenderId())
                 .senderName(chattingMessage.getSenderName())
                 .message(chattingMessage.getMessage())
+                .profilePicture(chattingMessage.getProfilePicture())
                 .unreadCount(chattingMessage.getUnreadCount())
                 .timeStamp(chattingMessage.getTimeStamp())
                 .messageType(chattingMessage.getMessageType())

--- a/src/main/java/com/gachtaxi/domain/chat/dto/response/ChattingRoomCountResponse.java
+++ b/src/main/java/com/gachtaxi/domain/chat/dto/response/ChattingRoomCountResponse.java
@@ -1,0 +1,10 @@
+package com.gachtaxi.domain.chat.dto.response;
+
+public record ChattingRoomCountResponse(
+        Long roomId,
+        Long totalParticipantCount
+) {
+    public static ChattingRoomCountResponse of(Long roomId, Long totalParticipantCount) {
+        return new ChattingRoomCountResponse(roomId, totalParticipantCount);
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/chat/entity/ChattingMessage.java
+++ b/src/main/java/com/gachtaxi/domain/chat/entity/ChattingMessage.java
@@ -25,6 +25,8 @@ public class ChattingMessage {
 
     private String senderName;
 
+    private String profilePicture;
+
     private Long roomId;
 
     private String message;
@@ -38,12 +40,13 @@ public class ChattingMessage {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-    public static ChattingMessage of(ChatMessageRequest request, long roomId, long senderId, String senderName, long unreadCount) {
+    public static ChattingMessage of(ChatMessageRequest request, long roomId, long senderId, String senderName, long unreadCount, String profilePicture) {
         return ChattingMessage.builder()
                 .senderId(senderId)
                 .senderName(senderName)
                 .roomId(roomId)
                 .message(request.message())
+                .profilePicture(profilePicture)
                 .unreadCount(unreadCount)
                 .messageType(MessageType.MESSAGE)
                 .timeStamp(LocalDateTime.now())

--- a/src/main/java/com/gachtaxi/domain/chat/entity/ChattingParticipant.java
+++ b/src/main/java/com/gachtaxi/domain/chat/entity/ChattingParticipant.java
@@ -35,6 +35,8 @@ public class ChattingParticipant extends BaseEntity {
     @CreatedDate
     private LocalDateTime lastReadAt;
 
+    private LocalDateTime disconnectedAt;
+
     public static ChattingParticipant of(ChattingRoom chattingRoom, Members members) {
         return ChattingParticipant.builder()
                 .chattingRoom(chattingRoom)
@@ -48,9 +50,11 @@ public class ChattingParticipant extends BaseEntity {
 
     public void unsubscribe() {
         this.lastReadAt = LocalDateTime.now();
+        this.disconnectedAt = LocalDateTime.now();
     }
 
     public void disconnect() {
         this.lastReadAt = LocalDateTime.now();
+        this.disconnectedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/gachtaxi/domain/chat/service/ChattingRedisService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChattingRedisService.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class ChattingRedisService {
@@ -45,13 +47,9 @@ public class ChattingRedisService {
     public String getProfilePicture(long roomId, long senderId) {
         String key = getKey(roomId);
 
-        Object profileImageUrl = chatRoomRedisTemplate.opsForHash().get(key, String.valueOf(senderId));
-
-        if (profileImageUrl == null) {
-            return null;
-        }
-
-        return profileImageUrl.toString();
+        return Optional.ofNullable(chatRoomRedisTemplate.opsForHash().get(key, String.valueOf(senderId)))
+                .map(Object::toString)
+                .orElse(null);
     }
 
     private String getKey(long roomId) {

--- a/src/main/java/com/gachtaxi/domain/chat/service/ChattingRoomService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChattingRoomService.java
@@ -1,6 +1,7 @@
 package com.gachtaxi.domain.chat.service;
 
 import com.gachtaxi.domain.chat.dto.request.ChatMessage;
+import com.gachtaxi.domain.chat.dto.response.ChattingRoomCountResponse;
 import com.gachtaxi.domain.chat.dto.response.ChattingRoomResponse;
 import com.gachtaxi.domain.chat.entity.ChattingMessage;
 import com.gachtaxi.domain.chat.entity.ChattingParticipant;
@@ -54,6 +55,13 @@ public class ChattingRoomService {
         ChattingRoom chattingRoom = find(chattingRoomId);
 
         chattingRoom.delete();
+    }
+
+    public ChattingRoomCountResponse getCount(Long memberId, Long roomId) {
+        chattingParticipantService.find(roomId, memberId);
+        Long count = chattingParticipantService.getParticipantCount(roomId);
+
+        return ChattingRoomCountResponse.of(roomId, count);
     }
 
     @Transactional

--- a/src/main/java/com/gachtaxi/domain/chat/service/ChattingRoomService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChattingRoomService.java
@@ -67,12 +67,12 @@ public class ChattingRoomService {
         accessor.getSessionAttributes().put(CHAT_USER_NAME, members.getNickname());
 
         if (chattingParticipantService.checkSubscription(chattingRoom, members)) {
-            chattingRedisService.saveSubscribeMember(chattingRoom.getId(), members.getId());
+            chattingRedisService.saveSubscribeMember(chattingRoom.getId(), members.getId(), members.getProfilePicture());
 
             return;
         }
 
-        chattingRedisService.saveSubscribeMember(chattingRoom.getId(), members.getId());
+        chattingRedisService.saveSubscribeMember(chattingRoom.getId(), members.getId(), members.getProfilePicture());
 
         ChattingParticipant newParticipant = ChattingParticipant.of(chattingRoom, members);
         chattingParticipantService.save(newParticipant);

--- a/src/main/java/com/gachtaxi/domain/chat/service/ChattingService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChattingService.java
@@ -100,7 +100,7 @@ public class ChattingService {
     }
 
     private Slice<ChattingMessage> loadInitialMessage(long roomId, ChattingParticipant chattingParticipant, int pageSize) {
-        int chattingCount = chattingMessageRepository.countAllByRoomIdAndTimeStampAfterOrderByTimeStampDesc(roomId, chattingParticipant.getLastReadAt());
+        int chattingCount = chattingMessageRepository.countAllByRoomIdAndTimeStampAfterOrderByTimeStampDesc(roomId, chattingParticipant.getDisconnectedAt());
 
         int effectivePageSize = Math.max(chattingCount, pageSize);
         Pageable pageable = PageRequest.of(0, effectivePageSize, Sort.by(Sort.Direction.DESC, "timeStamp"));

--- a/src/main/java/com/gachtaxi/domain/chat/service/ChattingService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChattingService.java
@@ -53,8 +53,9 @@ public class ChattingService {
         String senderName = getSessionAttribute(accessor, CHAT_USER_NAME, String.class);
 
         long unreadCount = getUnreadCount(roomId);
+        String profilePicture = chattingRedisService.getProfilePicture(roomId, userId);
 
-        ChattingMessage chattingMessage = ChattingMessage.of(request, roomId, userId, senderName, unreadCount);
+        ChattingMessage chattingMessage = ChattingMessage.of(request, roomId, userId, senderName, unreadCount, profilePicture);
 
         chattingMessageRepository.save(chattingMessage);
 


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #47 
Close #


## 🚀 작업 내용
- 채팅 조회, 실시간 채팅시 프로필 이미지를 함께 보내도록 수정했습니다.
- 실시간 채팅에 매번 멤버 조회를 해서 프로필 이미지를 보여주는 것은 성능이 아쉬울 거라 판단해 redis에 함께 저장해 읽음 처리와 같이 사용하도록 했습니다.
- 그리고 해당 채팅방에 참여한 인원을 조회할 수 있는 API를 구현했습니다. 프론트엔드 측에서 원하는 시점에 조회할 수 있도록 했습니다.

## 📸 스크린샷


## 📢 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
