### PR TITLE
FIX # 55 presigned url 확장자 추가

### DIFF
--- a/src/main/java/com/gachtaxi/global/common/image/ImageUtil.java
+++ b/src/main/java/com/gachtaxi/global/common/image/ImageUtil.java
@@ -20,8 +20,8 @@ public class ImageUtil {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    public String generateUrl() {
-        String key = UUID.randomUUID().toString();
+    public String generateUrl(String fileName) {
+        String key = generateKey(fileName);
 
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(bucket)
@@ -36,5 +36,12 @@ public class ImageUtil {
         PresignedPutObjectRequest presignedUrlRequest = s3Presigner.presignPutObject(request);
 
         return presignedUrlRequest.url().toString();
+    }
+
+    private String generateKey(String fileName) {
+        String key = UUID.randomUUID().toString();
+        String extension = fileName.substring(fileName.lastIndexOf(".") + 1);
+
+        return key + "." + extension;
     }
 }

--- a/src/main/java/com/gachtaxi/global/common/image/controller/ImageController.java
+++ b/src/main/java/com/gachtaxi/global/common/image/controller/ImageController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import static com.gachtaxi.global.common.image.controller.ResponseMessage.PRESIGNED_URL_GENERATE_SUCCESS;
@@ -22,8 +23,8 @@ public class ImageController {
 
     @GetMapping()
     @Operation(summary = "Presigned Url 반환을 위한 요청 API 입니다.")
-    public ApiResponse<String> getPutUrl() {
-        String putUrl = imageUtil.generateUrl();
+    public ApiResponse<String> getPutUrl(@RequestParam String fileName) {
+        String putUrl = imageUtil.generateUrl(fileName);
 
         return ApiResponse.response(OK, PRESIGNED_URL_GENERATE_SUCCESS.getMessage(), putUrl);
     }


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #53 
Close #


## 🚀 작업 내용
- presigned url 반환시 파일의 확장자를 받아서 클라이언트에서 파일 처리시 문제가 없도록 수정했습니다.
- 업로드 완료한 파일을 get 요청했을 때 다운로드가 아니라 미리보기가 잘 이루어지는 것을 확인 했습니다

## 📸 스크린샷


## 📢 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
