### PR TITLE
Feat #56 친구 관련 기능 구현

### DIFF
--- a/src/main/java/com/gachtaxi/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/gachtaxi/domain/friend/controller/FriendController.java
@@ -49,4 +49,14 @@ public class FriendController {
         return ApiResponse.response(OK, FRIEND_STATUS_ACCEPTED.getMessage());
     }
 
+    @DeleteMapping
+    public ApiResponse<Void> deleteFriend(
+            @CurrentMemberId Long memberId,
+            @RequestBody FriendRequestDto dto
+    ) {
+        friendService.deleteFriend(memberId, dto.receiverId());
+
+        return ApiResponse.response(OK, FRIEND_DELETE.getMessage());
+    }
+
 }

--- a/src/main/java/com/gachtaxi/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/gachtaxi/domain/friend/controller/FriendController.java
@@ -7,9 +7,8 @@ import com.gachtaxi.domain.friend.service.FriendService;
 import com.gachtaxi.global.auth.jwt.annotation.CurrentMemberId;
 import com.gachtaxi.global.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 import static com.gachtaxi.domain.friend.controller.ResponseMessage.*;
 import static org.springframework.http.HttpStatus.OK;
@@ -32,11 +31,12 @@ public class FriendController {
 
     // 나의 친구를 반환하는 API
     @GetMapping
-    public ApiResponse<List<FriendsResponseDto>> getFriendsList(
-            @CurrentMemberId Long memberId
+    public ApiResponse<Slice<FriendsResponseDto>> getFriendsList(
+            @CurrentMemberId Long memberId,
+            @RequestParam int page,
+            @RequestParam int size
     ){
-
-        List<FriendsResponseDto> response = friendService.getFriendsList(memberId);
+        Slice<FriendsResponseDto> response = friendService.findFriendsListByMemberId(memberId, page, size);
         return ApiResponse.response(OK, FRIEND_LIST_SUCCESS.getMessage(), response);
     }
 

--- a/src/main/java/com/gachtaxi/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/gachtaxi/domain/friend/controller/FriendController.java
@@ -1,0 +1,33 @@
+package com.gachtaxi.domain.friend.controller;
+
+import com.gachtaxi.domain.friend.dto.request.FriendRequestDto;
+import com.gachtaxi.domain.friend.service.FriendService;
+import com.gachtaxi.global.auth.jwt.annotation.CurrentMemberId;
+import com.gachtaxi.global.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.gachtaxi.domain.friend.controller.ResponseMessage.FRIEND_REQUEST_SUCCESS;
+import static org.springframework.http.HttpStatus.OK;
+
+@RestController
+@RequestMapping("/api/friends")
+@RequiredArgsConstructor
+public class FriendController {
+
+    private final FriendService friendService;
+
+    @PostMapping
+    public ApiResponse<Void> sendFriendRequest(
+            @CurrentMemberId Long senderId,
+            @RequestBody FriendRequestDto dto
+    ){
+        friendService.sendFriendRequest(senderId, dto);
+        return ApiResponse.response(OK, FRIEND_REQUEST_SUCCESS.getMessage());
+    }
+
+
+}

--- a/src/main/java/com/gachtaxi/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/gachtaxi/domain/friend/controller/FriendController.java
@@ -48,12 +48,12 @@ public class FriendController {
         return ApiResponse.response(OK, FRIEND_STATUS_ACCEPTED.getMessage());
     }
 
-    @DeleteMapping
+    @DeleteMapping("/{memberId}")
     public ApiResponse<Void> deleteFriend(
-            @CurrentMemberId Long memberId,
-            @RequestBody FriendRequestDto dto
+            @CurrentMemberId Long currentId,
+            @PathVariable Long memberId
     ) {
-        friendService.deleteFriend(memberId, dto.memberId());
+        friendService.deleteFriend(currentId, memberId);
 
         return ApiResponse.response(OK, FRIEND_DELETE.getMessage());
     }

--- a/src/main/java/com/gachtaxi/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/gachtaxi/domain/friend/controller/FriendController.java
@@ -1,6 +1,7 @@
 package com.gachtaxi.domain.friend.controller;
 
 import com.gachtaxi.domain.friend.dto.request.FriendRequestDto;
+import com.gachtaxi.domain.friend.dto.request.FriendUpdateDto;
 import com.gachtaxi.domain.friend.dto.response.FriendsResponseDto;
 import com.gachtaxi.domain.friend.service.FriendService;
 import com.gachtaxi.global.auth.jwt.annotation.CurrentMemberId;
@@ -42,7 +43,7 @@ public class FriendController {
     @PatchMapping
     public ApiResponse<Void> acceptFriendRequest(
             @CurrentMemberId Long currentId,
-            @RequestBody FriendRequestDto dto
+            @RequestBody FriendUpdateDto dto
     ){
         friendService.updateFriendStatus(dto.memberId(), currentId); // 친구 요청 보낸 사람(dto), 받은 사람(토큰 추출)
         return ApiResponse.response(OK, FRIEND_STATUS_ACCEPTED.getMessage());

--- a/src/main/java/com/gachtaxi/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/gachtaxi/domain/friend/controller/FriendController.java
@@ -2,12 +2,11 @@ package com.gachtaxi.domain.friend.controller;
 
 import com.gachtaxi.domain.friend.dto.request.FriendRequestDto;
 import com.gachtaxi.domain.friend.dto.request.FriendUpdateDto;
-import com.gachtaxi.domain.friend.dto.response.FriendsResponseDto;
+import com.gachtaxi.domain.friend.dto.response.FriendsSliceResponse;
 import com.gachtaxi.domain.friend.service.FriendService;
 import com.gachtaxi.global.auth.jwt.annotation.CurrentMemberId;
 import com.gachtaxi.global.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Slice;
 import org.springframework.web.bind.annotation.*;
 
 import static com.gachtaxi.domain.friend.controller.ResponseMessage.*;
@@ -31,12 +30,12 @@ public class FriendController {
 
     // 나의 친구를 반환하는 API
     @GetMapping
-    public ApiResponse<Slice<FriendsResponseDto>> getFriendsList(
+    public ApiResponse<FriendsSliceResponse> getFriendsList(
             @CurrentMemberId Long memberId,
             @RequestParam int pageNum,
             @RequestParam int pageSize
     ){
-        Slice<FriendsResponseDto> response = friendService.findFriendsListByMemberId(memberId, pageNum, pageSize);
+        FriendsSliceResponse response = friendService.findFriendsListByMemberId(memberId, pageNum, pageSize);
         return ApiResponse.response(OK, FRIEND_LIST_SUCCESS.getMessage(), response);
     }
 

--- a/src/main/java/com/gachtaxi/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/gachtaxi/domain/friend/controller/FriendController.java
@@ -1,15 +1,16 @@
 package com.gachtaxi.domain.friend.controller;
 
 import com.gachtaxi.domain.friend.dto.request.FriendRequestDto;
+import com.gachtaxi.domain.friend.dto.response.FriendsResponseDto;
 import com.gachtaxi.domain.friend.service.FriendService;
 import com.gachtaxi.global.auth.jwt.annotation.CurrentMemberId;
 import com.gachtaxi.global.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
+import static com.gachtaxi.domain.friend.controller.ResponseMessage.FRIEND_LIST_SUCCESS;
 import static com.gachtaxi.domain.friend.controller.ResponseMessage.FRIEND_REQUEST_SUCCESS;
 import static org.springframework.http.HttpStatus.OK;
 
@@ -29,5 +30,14 @@ public class FriendController {
         return ApiResponse.response(OK, FRIEND_REQUEST_SUCCESS.getMessage());
     }
 
+    // 나의 친구를 반환하는 API
+    @GetMapping
+    public ApiResponse<List<FriendsResponseDto>> getFriendsList(
+            @CurrentMemberId Long memberId
+    ){
+
+        List<FriendsResponseDto> response = friendService.getFriendsList(memberId);
+        return ApiResponse.response(OK, FRIEND_LIST_SUCCESS.getMessage(), response);
+    }
 
 }

--- a/src/main/java/com/gachtaxi/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/gachtaxi/domain/friend/controller/FriendController.java
@@ -33,10 +33,10 @@ public class FriendController {
     @GetMapping
     public ApiResponse<Slice<FriendsResponseDto>> getFriendsList(
             @CurrentMemberId Long memberId,
-            @RequestParam int page,
-            @RequestParam int size
+            @RequestParam int pageNum,
+            @RequestParam int pageSize
     ){
-        Slice<FriendsResponseDto> response = friendService.findFriendsListByMemberId(memberId, page, size);
+        Slice<FriendsResponseDto> response = friendService.findFriendsListByMemberId(memberId, pageNum, pageSize);
         return ApiResponse.response(OK, FRIEND_LIST_SUCCESS.getMessage(), response);
     }
 

--- a/src/main/java/com/gachtaxi/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/gachtaxi/domain/friend/controller/FriendController.java
@@ -1,6 +1,7 @@
 package com.gachtaxi.domain.friend.controller;
 
 import com.gachtaxi.domain.friend.dto.request.FriendRequestDto;
+import com.gachtaxi.domain.friend.dto.request.FriendStatusUpdateReqeustDto;
 import com.gachtaxi.domain.friend.dto.response.FriendsResponseDto;
 import com.gachtaxi.domain.friend.service.FriendService;
 import com.gachtaxi.global.auth.jwt.annotation.CurrentMemberId;
@@ -10,8 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-import static com.gachtaxi.domain.friend.controller.ResponseMessage.FRIEND_LIST_SUCCESS;
-import static com.gachtaxi.domain.friend.controller.ResponseMessage.FRIEND_REQUEST_SUCCESS;
+import static com.gachtaxi.domain.friend.controller.ResponseMessage.*;
 import static org.springframework.http.HttpStatus.OK;
 
 @RestController
@@ -38,6 +38,15 @@ public class FriendController {
 
         List<FriendsResponseDto> response = friendService.getFriendsList(memberId);
         return ApiResponse.response(OK, FRIEND_LIST_SUCCESS.getMessage(), response);
+    }
+
+    @PatchMapping
+    public ApiResponse<Void> acceptFriendRequest(
+            @CurrentMemberId Long receiverId,
+            @RequestBody FriendStatusUpdateReqeustDto dto
+    ){
+        friendService.updateFriendStatus(receiverId, dto);
+        return ApiResponse.response(OK, FRIEND_STATUS_ACCEPTED.getMessage());
     }
 
 }

--- a/src/main/java/com/gachtaxi/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/gachtaxi/domain/friend/controller/FriendController.java
@@ -1,7 +1,6 @@
 package com.gachtaxi.domain.friend.controller;
 
 import com.gachtaxi.domain.friend.dto.request.FriendRequestDto;
-import com.gachtaxi.domain.friend.dto.request.FriendStatusUpdateReqeustDto;
 import com.gachtaxi.domain.friend.dto.response.FriendsResponseDto;
 import com.gachtaxi.domain.friend.service.FriendService;
 import com.gachtaxi.global.auth.jwt.annotation.CurrentMemberId;
@@ -42,10 +41,10 @@ public class FriendController {
 
     @PatchMapping
     public ApiResponse<Void> acceptFriendRequest(
-            @CurrentMemberId Long receiverId,
-            @RequestBody FriendStatusUpdateReqeustDto dto
+            @CurrentMemberId Long currentId,
+            @RequestBody FriendRequestDto dto
     ){
-        friendService.updateFriendStatus(receiverId, dto);
+        friendService.updateFriendStatus(dto.memberId(), currentId); // 친구 요청 보낸 사람(dto), 받은 사람(토큰 추출)
         return ApiResponse.response(OK, FRIEND_STATUS_ACCEPTED.getMessage());
     }
 
@@ -54,7 +53,7 @@ public class FriendController {
             @CurrentMemberId Long memberId,
             @RequestBody FriendRequestDto dto
     ) {
-        friendService.deleteFriend(memberId, dto.receiverId());
+        friendService.deleteFriend(memberId, dto.memberId());
 
         return ApiResponse.response(OK, FRIEND_DELETE.getMessage());
     }

--- a/src/main/java/com/gachtaxi/domain/friend/controller/ResponseMessage.java
+++ b/src/main/java/com/gachtaxi/domain/friend/controller/ResponseMessage.java
@@ -1,0 +1,17 @@
+package com.gachtaxi.domain.friend.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseMessage {
+
+    FRIEND_REQUEST_SUCCESS("친구 요청을 보냈습니다."),
+    FRIEND_STATUS_ACCEPTED("친구 요청을 수락했습니다"),
+    FRIEND_STATUS_REJECTED("친구 요청을 거절했습니다"),
+    FRIEND_DELETE("친구를 삭제했습니다."),
+    FRIEND_LIST_SUCCESS("친구 목록을 조회합니다");
+
+    private final String message;
+}

--- a/src/main/java/com/gachtaxi/domain/friend/dto/request/FriendRequestDto.java
+++ b/src/main/java/com/gachtaxi/domain/friend/dto/request/FriendRequestDto.java
@@ -1,0 +1,8 @@
+package com.gachtaxi.domain.friend.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record FriendRequestDto(
+        @NotNull Long receiverId
+) {
+}

--- a/src/main/java/com/gachtaxi/domain/friend/dto/request/FriendRequestDto.java
+++ b/src/main/java/com/gachtaxi/domain/friend/dto/request/FriendRequestDto.java
@@ -3,6 +3,6 @@ package com.gachtaxi.domain.friend.dto.request;
 import jakarta.validation.constraints.NotNull;
 
 public record FriendRequestDto(
-        @NotNull Long receiverId
+        @NotNull Long memberId
 ) {
 }

--- a/src/main/java/com/gachtaxi/domain/friend/dto/request/FriendStatusUpdateReqeustDto.java
+++ b/src/main/java/com/gachtaxi/domain/friend/dto/request/FriendStatusUpdateReqeustDto.java
@@ -1,0 +1,8 @@
+package com.gachtaxi.domain.friend.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record FriendStatusUpdateReqeustDto(
+        @NotNull Long senderId
+) {
+}

--- a/src/main/java/com/gachtaxi/domain/friend/dto/request/FriendUpdateDto.java
+++ b/src/main/java/com/gachtaxi/domain/friend/dto/request/FriendUpdateDto.java
@@ -2,7 +2,7 @@ package com.gachtaxi.domain.friend.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 
-public record FriendRequestDto(
-        @NotNull String nickName
+public record FriendUpdateDto(
+        @NotNull Long memberId
 ) {
 }

--- a/src/main/java/com/gachtaxi/domain/friend/dto/response/FriendsPageableResponse.java
+++ b/src/main/java/com/gachtaxi/domain/friend/dto/response/FriendsPageableResponse.java
@@ -1,0 +1,22 @@
+package com.gachtaxi.domain.friend.dto.response;
+
+import com.gachtaxi.domain.friend.entity.Friends;
+import lombok.Builder;
+import org.springframework.data.domain.Slice;
+
+@Builder
+public record FriendsPageableResponse(
+        int pageNum,
+        int pageSize,
+        int numberOfElements,
+        boolean isLast
+) {
+    public static FriendsPageableResponse from(Slice<Friends> slice) {
+        return FriendsPageableResponse.builder()
+                .pageNum(slice.getNumber())
+                .pageSize(slice.getSize())
+                .numberOfElements(slice.getNumberOfElements())
+                .isLast(slice.isLast())
+                .build();
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/friend/dto/response/FriendsResponseDto.java
+++ b/src/main/java/com/gachtaxi/domain/friend/dto/response/FriendsResponseDto.java
@@ -19,4 +19,12 @@ public record FriendsResponseDto(
                 .gender(friends.getGender())
                 .build();
     }
+
+    // Constructor for JPQL Result - DTO Mapping
+    public FriendsResponseDto(Long friendsId, String friendsNickName, String friendsProfileUrl, Gender gender) {
+        this.friendsId = friendsId;
+        this.friendsNickName = friendsNickName;
+        this.friendsProfileUrl = friendsProfileUrl;
+        this.gender = gender;
+    }
 }

--- a/src/main/java/com/gachtaxi/domain/friend/dto/response/FriendsResponseDto.java
+++ b/src/main/java/com/gachtaxi/domain/friend/dto/response/FriendsResponseDto.java
@@ -1,19 +1,22 @@
 package com.gachtaxi.domain.friend.dto.response;
 
 import com.gachtaxi.domain.members.entity.Members;
+import com.gachtaxi.domain.members.entity.enums.Gender;
 import lombok.Builder;
 
 @Builder
 public record FriendsResponseDto(
         Long friendsId,
         String friendsNickName,
-        String friendsProfileUrl
+        String friendsProfileUrl,
+        Gender gender
 ) {
     public static FriendsResponseDto from(Members friends) {
         return FriendsResponseDto.builder()
                 .friendsId(friends.getId())
                 .friendsNickName(friends.getNickname())
                 .friendsProfileUrl(friends.getProfilePicture())
+                .gender(friends.getGender())
                 .build();
     }
 }

--- a/src/main/java/com/gachtaxi/domain/friend/dto/response/FriendsResponseDto.java
+++ b/src/main/java/com/gachtaxi/domain/friend/dto/response/FriendsResponseDto.java
@@ -1,0 +1,19 @@
+package com.gachtaxi.domain.friend.dto.response;
+
+import com.gachtaxi.domain.members.entity.Members;
+import lombok.Builder;
+
+@Builder
+public record FriendsResponseDto(
+        Long friendsId,
+        String friendsNickName,
+        String friendsProfileUrl
+) {
+    public static FriendsResponseDto from(Members friends) {
+        return FriendsResponseDto.builder()
+                .friendsId(friends.getId())
+                .friendsNickName(friends.getNickname())
+                .friendsProfileUrl(friends.getProfilePicture())
+                .build();
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/friend/dto/response/FriendsSliceResponse.java
+++ b/src/main/java/com/gachtaxi/domain/friend/dto/response/FriendsSliceResponse.java
@@ -1,0 +1,18 @@
+package com.gachtaxi.domain.friend.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record FriendsSliceResponse(
+        List<FriendsResponseDto> response,
+        FriendsPageableResponse pageable
+) {
+    public static FriendsSliceResponse of(List<FriendsResponseDto> response, FriendsPageableResponse pageable) {
+        return FriendsSliceResponse.builder()
+                .response(response)
+                .pageable(pageable)
+                .build();
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/friend/entity/Friends.java
+++ b/src/main/java/com/gachtaxi/domain/friend/entity/Friends.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import static com.gachtaxi.domain.friend.entity.enums.FriendStatus.ACCEPTED;
 import static com.gachtaxi.domain.friend.entity.enums.FriendStatus.PENDING;
 
 
@@ -41,7 +42,7 @@ public class Friends extends BaseEntity {
                 .build();
     }
 
-    public void updateStatus(FriendStatus status){
-        this.status = status;
+    public void updateStatus(){
+        this.status = ACCEPTED;
     }
 }

--- a/src/main/java/com/gachtaxi/domain/friend/entity/Friends.java
+++ b/src/main/java/com/gachtaxi/domain/friend/entity/Friends.java
@@ -1,0 +1,41 @@
+package com.gachtaxi.domain.friend.entity;
+
+import com.gachtaxi.domain.friend.entity.enums.FriendStatus;
+import com.gachtaxi.domain.members.entity.Members;
+import com.gachtaxi.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import static com.gachtaxi.domain.friend.entity.enums.FriendStatus.PENDING;
+
+
+@Entity
+@Getter
+@Table(name="Friends")
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Friends extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id")
+    private Members sender;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id")
+    private Members receiver;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    private FriendStatus status = PENDING;
+
+    public static Friends of(Members sender, Members receiver) {
+        return Friends.builder()
+                .sender(sender)
+                .receiver(receiver)
+                .build();
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/friend/entity/Friends.java
+++ b/src/main/java/com/gachtaxi/domain/friend/entity/Friends.java
@@ -15,8 +15,10 @@ import static com.gachtaxi.domain.friend.entity.enums.FriendStatus.PENDING;
 
 @Entity
 @Getter
-@Table(name="Friends")
-@SuperBuilder
+@Table(
+        name = "Friends",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"sender_id", "receiver_id"})
+)@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Friends extends BaseEntity {
 
@@ -37,5 +39,9 @@ public class Friends extends BaseEntity {
                 .sender(sender)
                 .receiver(receiver)
                 .build();
+    }
+
+    public void updateStatus(FriendStatus status){
+        this.status = status;
     }
 }

--- a/src/main/java/com/gachtaxi/domain/friend/entity/enums/FriendStatus.java
+++ b/src/main/java/com/gachtaxi/domain/friend/entity/enums/FriendStatus.java
@@ -1,5 +1,5 @@
 package com.gachtaxi.domain.friend.entity.enums;
 
 public enum FriendStatus {
-    PENDING, ACCEPTED, REJECTED
+    PENDING, ACCEPTED
 }

--- a/src/main/java/com/gachtaxi/domain/friend/entity/enums/FriendStatus.java
+++ b/src/main/java/com/gachtaxi/domain/friend/entity/enums/FriendStatus.java
@@ -1,0 +1,5 @@
+package com.gachtaxi.domain.friend.entity.enums;
+
+public enum FriendStatus {
+    PENDING, ACCEPTED, REJECTED
+}

--- a/src/main/java/com/gachtaxi/domain/friend/exception/ErrorMessage.java
+++ b/src/main/java/com/gachtaxi/domain/friend/exception/ErrorMessage.java
@@ -1,0 +1,14 @@
+package com.gachtaxi.domain.friend.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+
+    FRIEND_SHIP_EXISTS("이미 친구 입니다."),
+    FRIEND_SHIP_PENDING("친구 요청 대기중입니다.");
+
+    private final String message;
+}

--- a/src/main/java/com/gachtaxi/domain/friend/exception/ErrorMessage.java
+++ b/src/main/java/com/gachtaxi/domain/friend/exception/ErrorMessage.java
@@ -7,8 +7,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorMessage {
 
-    FRIEND_SHIP_EXISTS("이미 친구 입니다."),
-    FRIEND_SHIP_PENDING("친구 요청 대기중입니다.");
+    FRIEND_DO_NOT_SEND_MYSELF("자기 자신에게 친구 요청을 보낼 수 없어요"),
+    FRIEND_NOT_EXISTS("잘못된 친구 관계입니다."),
+    FRIEND_EXISTS("이미 친구 입니다."),
+    FRIEND_PENDING("친구 요청 대기중입니다.");
 
     private final String message;
 }

--- a/src/main/java/com/gachtaxi/domain/friend/exception/FriendNotExistsException.java
+++ b/src/main/java/com/gachtaxi/domain/friend/exception/FriendNotExistsException.java
@@ -1,0 +1,12 @@
+package com.gachtaxi.domain.friend.exception;
+
+import com.gachtaxi.global.common.exception.BaseException;
+
+import static com.gachtaxi.domain.friend.exception.ErrorMessage.FRIEND_NOT_EXISTS;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class FriendNotExistsException extends BaseException {
+    public FriendNotExistsException() {
+        super(BAD_REQUEST, FRIEND_NOT_EXISTS.getMessage());
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/friend/exception/FriendShipDoesNotSendMySelfException.java
+++ b/src/main/java/com/gachtaxi/domain/friend/exception/FriendShipDoesNotSendMySelfException.java
@@ -1,0 +1,12 @@
+package com.gachtaxi.domain.friend.exception;
+
+import com.gachtaxi.global.common.exception.BaseException;
+
+import static com.gachtaxi.domain.friend.exception.ErrorMessage.FRIEND_DO_NOT_SEND_MYSELF;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class FriendShipDoesNotSendMySelfException extends BaseException {
+    public FriendShipDoesNotSendMySelfException() {
+        super(BAD_REQUEST, FRIEND_DO_NOT_SEND_MYSELF.getMessage());
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/friend/exception/FriendShipExistsException.java
+++ b/src/main/java/com/gachtaxi/domain/friend/exception/FriendShipExistsException.java
@@ -1,0 +1,12 @@
+package com.gachtaxi.domain.friend.exception;
+
+import com.gachtaxi.global.common.exception.BaseException;
+
+import static com.gachtaxi.domain.friend.exception.ErrorMessage.FRIEND_SHIP_EXISTS;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class FriendShipExistsException extends BaseException {
+    public FriendShipExistsException() {
+        super(BAD_REQUEST, FRIEND_SHIP_EXISTS.getMessage());
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/friend/exception/FriendShipExistsException.java
+++ b/src/main/java/com/gachtaxi/domain/friend/exception/FriendShipExistsException.java
@@ -2,11 +2,11 @@ package com.gachtaxi.domain.friend.exception;
 
 import com.gachtaxi.global.common.exception.BaseException;
 
-import static com.gachtaxi.domain.friend.exception.ErrorMessage.FRIEND_SHIP_EXISTS;
+import static com.gachtaxi.domain.friend.exception.ErrorMessage.FRIEND_EXISTS;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 public class FriendShipExistsException extends BaseException {
     public FriendShipExistsException() {
-        super(BAD_REQUEST, FRIEND_SHIP_EXISTS.getMessage());
+        super(BAD_REQUEST, FRIEND_EXISTS.getMessage());
     }
 }

--- a/src/main/java/com/gachtaxi/domain/friend/exception/FriendShipPendingException.java
+++ b/src/main/java/com/gachtaxi/domain/friend/exception/FriendShipPendingException.java
@@ -1,0 +1,12 @@
+package com.gachtaxi.domain.friend.exception;
+
+import com.gachtaxi.global.common.exception.BaseException;
+
+import static com.gachtaxi.domain.friend.exception.ErrorMessage.FRIEND_SHIP_PENDING;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class FriendShipPendingException extends BaseException {
+    public FriendShipPendingException() {
+        super(BAD_REQUEST, FRIEND_SHIP_PENDING.getMessage());
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/friend/exception/FriendShipPendingException.java
+++ b/src/main/java/com/gachtaxi/domain/friend/exception/FriendShipPendingException.java
@@ -2,11 +2,11 @@ package com.gachtaxi.domain.friend.exception;
 
 import com.gachtaxi.global.common.exception.BaseException;
 
-import static com.gachtaxi.domain.friend.exception.ErrorMessage.FRIEND_SHIP_PENDING;
+import static com.gachtaxi.domain.friend.exception.ErrorMessage.FRIEND_PENDING;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 public class FriendShipPendingException extends BaseException {
     public FriendShipPendingException() {
-        super(BAD_REQUEST, FRIEND_SHIP_PENDING.getMessage());
+        super(BAD_REQUEST, FRIEND_PENDING.getMessage());
     }
 }

--- a/src/main/java/com/gachtaxi/domain/friend/mapper/FriendsMapper.java
+++ b/src/main/java/com/gachtaxi/domain/friend/mapper/FriendsMapper.java
@@ -1,0 +1,15 @@
+package com.gachtaxi.domain.friend.mapper;
+
+import com.gachtaxi.domain.friend.dto.response.FriendsResponseDto;
+import com.gachtaxi.domain.friend.entity.Friends;
+
+public class FriendsMapper {
+
+    public static FriendsResponseDto toResponseDto(Friends friends, Long memberId) {
+        if(friends.getSender().getId().equals(memberId)) {
+            return FriendsResponseDto.from(friends.getReceiver());
+        }else{
+            return FriendsResponseDto.from(friends.getSender());
+        }
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/gachtaxi/domain/friend/repository/FriendRepository.java
@@ -1,18 +1,26 @@
 package com.gachtaxi.domain.friend.repository;
 
 import com.gachtaxi.domain.friend.entity.Friends;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface FriendRepository extends JpaRepository<Friends, Long> {
 
+    @Query("SELECT f FROM Friends f " +
+            "JOIN FETCH f.sender " +
+            "JOIN FETCH f.receiver " +
+            "WHERE f.status = 'ACCEPTED' AND " +
+            "(f.sender.id = :memberId OR f.receiver.id = :memberId)")
+    List<Friends> findAcceptedFriendsByMemberId(@Param("memberId") Long memberId);
+
     @Query("SELECT f FROM Friends f WHERE" +
             "(f.sender.id = :member1Id AND f.receiver.id = :member2Id) OR" +
             "(f.sender.id = :member2Id AND f.receiver.id = :member1Id)")
     Optional<Friends> findFriendShip(Long member1Id, Long member2Id);
-
 }

--- a/src/main/java/com/gachtaxi/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/gachtaxi/domain/friend/repository/FriendRepository.java
@@ -1,5 +1,6 @@
 package com.gachtaxi.domain.friend.repository;
 
+import com.gachtaxi.domain.friend.dto.response.FriendsResponseDto;
 import com.gachtaxi.domain.friend.entity.Friends;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,12 +13,23 @@ import java.util.Optional;
 @Repository
 public interface FriendRepository extends JpaRepository<Friends, Long> {
 
-    @Query("SELECT f FROM Friends f " +
-            "JOIN FETCH f.sender " +
-            "JOIN FETCH f.receiver " +
-            "WHERE f.status = 'ACCEPTED' AND " +
-            "(f.sender.id = :memberId OR f.receiver.id = :memberId)")
-    List<Friends> findAcceptedFriendsByMemberId(@Param("memberId") Long memberId);
+//    @Query("SELECT f FROM Friends f " +
+//            "JOIN FETCH f.sender " +
+//            "JOIN FETCH f.receiver " +
+//            "WHERE f.status = 'ACCEPTED' AND " +
+//            "(f.sender.id = :memberId OR f.receiver.id = :memberId)")
+//    List<Friends> findAcceptedFriendsByMemberId(@Param("memberId") Long memberId);
+
+    @Query("SELECT new com.gachtaxi.domain.friend.dto.response.FriendsResponseDto( " +
+            "CASE WHEN f.sender.id = :memberId THEN f.receiver.id ELSE f.sender.id END, " +
+            "CASE WHEN f.sender.id = :memberId THEN f.receiver.nickname ELSE f.sender.nickname END, " +
+            "CASE WHEN f.sender.id = :memberId THEN f.receiver.profilePicture ELSE f.sender.profilePicture END, " +
+            "CASE WHEN f.sender.id = :memberId THEN f.receiver.gender ELSE f.sender.gender END " +
+            ") FROM Friends f " +
+            "WHERE f.status = 'ACCEPTED' " +
+            "AND (f.sender.id = :memberId OR f.receiver.id = :memberId)")
+    List<FriendsResponseDto> findAcceptedFriendsByMemberId(@Param("memberId") Long memberId);
+
 
     @Query("SELECT f FROM Friends f WHERE" +
             "(f.sender.id = :member1Id AND f.receiver.id = :member2Id) OR" +

--- a/src/main/java/com/gachtaxi/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/gachtaxi/domain/friend/repository/FriendRepository.java
@@ -13,13 +13,6 @@ import java.util.Optional;
 @Repository
 public interface FriendRepository extends JpaRepository<Friends, Long> {
 
-//    @Query("SELECT f FROM Friends f " +
-//            "JOIN FETCH f.sender " +
-//            "JOIN FETCH f.receiver " +
-//            "WHERE f.status = 'ACCEPTED' AND " +
-//            "(f.sender.id = :memberId OR f.receiver.id = :memberId)")
-//    List<Friends> findAcceptedFriendsByMemberId(@Param("memberId") Long memberId);
-
     @Query("SELECT new com.gachtaxi.domain.friend.dto.response.FriendsResponseDto( " +
             "CASE WHEN f.sender.id = :memberId THEN f.receiver.id ELSE f.sender.id END, " +
             "CASE WHEN f.sender.id = :memberId THEN f.receiver.nickname ELSE f.sender.nickname END, " +

--- a/src/main/java/com/gachtaxi/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/gachtaxi/domain/friend/repository/FriendRepository.java
@@ -23,4 +23,6 @@ public interface FriendRepository extends JpaRepository<Friends, Long> {
             "(f.sender.id = :member1Id AND f.receiver.id = :member2Id) OR" +
             "(f.sender.id = :member2Id AND f.receiver.id = :member1Id)")
     Optional<Friends> findFriendShip(Long member1Id, Long member2Id);
+
+    Optional<Friends> findBySenderIdAndReceiverId(Long senderId, Long receiverId);
 }

--- a/src/main/java/com/gachtaxi/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/gachtaxi/domain/friend/repository/FriendRepository.java
@@ -1,0 +1,18 @@
+package com.gachtaxi.domain.friend.repository;
+
+import com.gachtaxi.domain.friend.entity.Friends;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface FriendRepository extends JpaRepository<Friends, Long> {
+
+    @Query("SELECT f FROM Friends f WHERE" +
+            "(f.sender.id = :member1Id AND f.receiver.id = :member2Id) OR" +
+            "(f.sender.id = :member2Id AND f.receiver.id = :member1Id)")
+    Optional<Friends> findFriendShip(Long member1Id, Long member2Id);
+
+}

--- a/src/main/java/com/gachtaxi/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/gachtaxi/domain/friend/repository/FriendRepository.java
@@ -1,28 +1,24 @@
 package com.gachtaxi.domain.friend.repository;
 
-import com.gachtaxi.domain.friend.dto.response.FriendsResponseDto;
 import com.gachtaxi.domain.friend.entity.Friends;
 import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface FriendRepository extends JpaRepository<Friends, Long> {
 
-    @Query("SELECT new com.gachtaxi.domain.friend.dto.response.FriendsResponseDto( " +
-            "CASE WHEN f.sender.id = :memberId THEN f.receiver.id ELSE f.sender.id END, " +
-            "CASE WHEN f.sender.id = :memberId THEN f.receiver.nickname ELSE f.sender.nickname END, " +
-            "CASE WHEN f.sender.id = :memberId THEN f.receiver.profilePicture ELSE f.sender.profilePicture END, " +
-            "CASE WHEN f.sender.id = :memberId THEN f.receiver.gender ELSE f.sender.gender END " +
-            ") FROM Friends f " +
-            "WHERE f.status = 'ACCEPTED' " +
-            "AND (f.sender.id = :memberId OR f.receiver.id = :memberId)")
-    List<FriendsResponseDto> findAcceptedFriendsByMemberId(@Param("memberId") Long memberId);
-
+    @Query("SELECT f FROM Friends f " +
+            "JOIN FETCH f.sender s " +
+            "JOIN FETCH f.receiver r " +
+            "WHERE (s.id = :memberId OR r.id = :memberId) " +
+            "AND f.status = 'ACCEPTED'")
+    Slice<Friends> findFriendsListByMemberId(@Param("memberId") Long memberId, Pageable pageable);
 
     @Query("SELECT f FROM Friends f WHERE" +
             "(f.sender.id = :member1Id AND f.receiver.id = :member2Id) OR" +

--- a/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
+++ b/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
@@ -1,11 +1,13 @@
 package com.gachtaxi.domain.friend.service;
 
 import com.gachtaxi.domain.friend.dto.request.FriendRequestDto;
+import com.gachtaxi.domain.friend.dto.response.FriendsResponseDto;
 import com.gachtaxi.domain.friend.entity.Friends;
 import com.gachtaxi.domain.friend.entity.enums.FriendStatus;
 import com.gachtaxi.domain.friend.exception.FriendShipDoesNotSendMySelfException;
 import com.gachtaxi.domain.friend.exception.FriendShipExistsException;
 import com.gachtaxi.domain.friend.exception.FriendShipPendingException;
+import com.gachtaxi.domain.friend.mapper.FriendsMapper;
 import com.gachtaxi.domain.friend.repository.FriendRepository;
 import com.gachtaxi.domain.members.entity.Members;
 import com.gachtaxi.domain.members.service.MemberService;
@@ -14,6 +16,8 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 import static com.gachtaxi.domain.notification.entity.enums.NotificationType.FRIEND_REQUEST;
 
@@ -43,6 +47,15 @@ public class FriendService {
                 String.format(FRIEND_REQUEST_MESSAGE, sender.getNickname()));
     }
 
+    public List<FriendsResponseDto> getFriendsList(Long memberId){
+        List<Friends> friendsList = getAcceptedFriendsList(memberId);
+
+        return friendsList.stream()
+                .map(friends -> FriendsMapper.toResponseDto(friends, memberId))
+                .toList();
+    }
+
+
 
     public void checkDuplicatedFriendShip(Long senderId, Long receiverId) {
         if(senderId.equals(receiverId)) { // 자기 자신한테 친구 요청을 보낼 경우
@@ -59,4 +72,10 @@ public class FriendService {
                     }
                 });
     }
+
+    public List<Friends> getAcceptedFriendsList(Long memberId) {
+        return friendRepository.findAcceptedFriendsByMemberId(memberId);
+    }
+
+
 }

--- a/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
+++ b/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
@@ -1,7 +1,9 @@
 package com.gachtaxi.domain.friend.service;
 
 import com.gachtaxi.domain.friend.dto.request.FriendRequestDto;
+import com.gachtaxi.domain.friend.dto.response.FriendsPageableResponse;
 import com.gachtaxi.domain.friend.dto.response.FriendsResponseDto;
+import com.gachtaxi.domain.friend.dto.response.FriendsSliceResponse;
 import com.gachtaxi.domain.friend.entity.Friends;
 import com.gachtaxi.domain.friend.entity.enums.FriendStatus;
 import com.gachtaxi.domain.friend.exception.FriendNotExistsException;
@@ -20,6 +22,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -48,12 +52,18 @@ public class FriendService {
 //                String.format(FRIEND_REQUEST_MESSAGE, sender.getNickname()));
     }
 
-    public Slice<FriendsResponseDto> findFriendsListByMemberId(Long memberId, int pageNum, int pageSize) {
+    public FriendsSliceResponse findFriendsListByMemberId(Long memberId, int pageNum, int pageSize) {
         Pageable pageable = PageRequest.of(pageNum, pageSize);
 
         Slice<Friends> friendsList = friendRepository.findFriendsListByMemberId(memberId, pageable);
 
-        return friendsList.map(f -> FriendsMapper.toResponseDto(f, memberId));
+        List<FriendsResponseDto> friendsListDto = friendsList
+                .map(f -> FriendsMapper.toResponseDto(f, memberId))
+                .toList();
+
+        FriendsPageableResponse pageableResponse = FriendsPageableResponse.from(friendsList);
+
+        return FriendsSliceResponse.of(friendsListDto, pageableResponse);
     }
 
     @Transactional

--- a/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
+++ b/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
@@ -1,0 +1,62 @@
+package com.gachtaxi.domain.friend.service;
+
+import com.gachtaxi.domain.friend.dto.request.FriendRequestDto;
+import com.gachtaxi.domain.friend.entity.Friends;
+import com.gachtaxi.domain.friend.entity.enums.FriendStatus;
+import com.gachtaxi.domain.friend.exception.FriendShipDoesNotSendMySelfException;
+import com.gachtaxi.domain.friend.exception.FriendShipExistsException;
+import com.gachtaxi.domain.friend.exception.FriendShipPendingException;
+import com.gachtaxi.domain.friend.repository.FriendRepository;
+import com.gachtaxi.domain.members.entity.Members;
+import com.gachtaxi.domain.members.service.MemberService;
+import com.gachtaxi.domain.notification.service.NotificationService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import static com.gachtaxi.domain.notification.entity.enums.NotificationType.FRIEND_REQUEST;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FriendService {
+
+    private final FriendRepository friendRepository;
+    private final NotificationService notificationService;
+    private final MemberService memberService;
+
+    public static final String FRIEND_REQUEST_MESSAGE = "%s 님이 친구 요청을 보냈어요.";
+
+    @Transactional
+    public void sendFriendRequest(Long senderId, FriendRequestDto dto) {
+        Members sender = memberService.findById(senderId);
+        Members recevier = memberService.findById(dto.receiverId());
+
+        checkDuplicatedFriendShip(senderId, recevier.getId());
+        friendRepository.save(Friends.of(sender, recevier));
+
+        notificationService.sendWithPush(
+                sender.getId(),
+                recevier,
+                FRIEND_REQUEST,
+                String.format(FRIEND_REQUEST_MESSAGE, sender.getNickname()));
+    }
+
+
+    public void checkDuplicatedFriendShip(Long senderId, Long receiverId) {
+        if(senderId.equals(receiverId)) { // 자기 자신한테 친구 요청을 보낼 경우
+            throw new FriendShipDoesNotSendMySelfException();
+        }
+
+        friendRepository.findFriendShip(senderId, receiverId)
+                .ifPresent(f -> {
+                    if(f.getStatus() == FriendStatus.ACCEPTED) { // 이미 친구 관계인 경우
+                        throw new FriendShipExistsException();
+                    }
+                    if(f.getStatus() == FriendStatus.PENDING) { // 친구 요청 대기중인 경우
+                        throw new FriendShipPendingException();
+                    }
+                });
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
+++ b/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
@@ -19,8 +19,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
-import static com.gachtaxi.domain.notification.entity.enums.NotificationType.FRIEND_REQUEST;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -41,11 +39,11 @@ public class FriendService {
         checkDuplicatedFriendShip(senderId, receiver.getId());
         friendRepository.save(Friends.of(sender, receiver));
 
-        notificationService.sendWithPush(
-                sender.getId(),
-                receiver,
-                FRIEND_REQUEST,
-                String.format(FRIEND_REQUEST_MESSAGE, sender.getNickname()));
+//        notificationService.sendWithPush(
+//                sender.getId(),
+//                receiver,
+//                FRIEND_REQUEST,
+//                String.format(FRIEND_REQUEST_MESSAGE, sender.getNickname()));
     }
 
     public List<FriendsResponseDto> getFriendsList(Long memberId){

--- a/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
+++ b/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
@@ -14,6 +14,7 @@ import com.gachtaxi.domain.friend.mapper.FriendsMapper;
 import com.gachtaxi.domain.friend.repository.FriendRepository;
 import com.gachtaxi.domain.members.entity.Members;
 import com.gachtaxi.domain.members.service.MemberService;
+import com.gachtaxi.domain.notification.entity.payload.FriendRequestPayload;
 import com.gachtaxi.domain.notification.service.NotificationService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,8 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+import static com.gachtaxi.domain.notification.entity.enums.NotificationType.FRIEND_REQUEST;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -34,7 +37,8 @@ public class FriendService {
     private final NotificationService notificationService;
     private final MemberService memberService;
 
-    public static final String FRIEND_REQUEST_MESSAGE = "%s 님이 친구 요청을 보냈어요.";
+    public static final String FRIEND_REQUEST_CONTENT = "%s 님이 친구 요청을 보냈어요.";
+    public static final String FRIEND_REQUEST_TITLE = "친구 요청";
 
     @Transactional
     public void sendFriendRequest(Long senderId, FriendRequestDto dto) {
@@ -45,11 +49,13 @@ public class FriendService {
         checkDuplicatedFriendShip(senderId, receiver.getId());
         friendRepository.save(Friends.of(sender, receiver));
 
-//        notificationService.sendWithPush(
-//                sender.getId(),
-//                receiver,
-//                FRIEND_REQUEST,
-//                String.format(FRIEND_REQUEST_MESSAGE, sender.getNickname()));
+        notificationService.sendWithPush(
+                sender.getId(),
+                receiver,
+                FRIEND_REQUEST,
+                FRIEND_REQUEST_TITLE,
+                String.format(FRIEND_REQUEST_CONTENT, sender.getNickname()),
+                FriendRequestPayload.from(senderId));
     }
 
     public FriendsSliceResponse findFriendsListByMemberId(Long memberId, int pageNum, int pageSize) {

--- a/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
+++ b/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
@@ -63,6 +63,14 @@ public class FriendService {
         friendShip.updateStatus();
     }
 
+    public void deleteFriend(Long memberId, Long receiverId) {
+        Friends friendShip = getFriendShip(memberId, receiverId);
+        friendRepository.delete(friendShip);
+    }
+
+    /*
+    * refactoring
+    * */
 
     public void checkDuplicatedFriendShip(Long senderId, Long receiverId) {
         if(senderId.equals(receiverId)) { // 자기 자신한테 친구 요청을 보낼 경우

--- a/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
+++ b/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
@@ -1,7 +1,6 @@
 package com.gachtaxi.domain.friend.service;
 
 import com.gachtaxi.domain.friend.dto.request.FriendRequestDto;
-import com.gachtaxi.domain.friend.dto.request.FriendStatusUpdateReqeustDto;
 import com.gachtaxi.domain.friend.dto.response.FriendsResponseDto;
 import com.gachtaxi.domain.friend.entity.Friends;
 import com.gachtaxi.domain.friend.entity.enums.FriendStatus;
@@ -37,14 +36,14 @@ public class FriendService {
     @Transactional
     public void sendFriendRequest(Long senderId, FriendRequestDto dto) {
         Members sender = memberService.findById(senderId);
-        Members recevier = memberService.findById(dto.receiverId());
+        Members receiver = memberService.findById(dto.memberId());
 
-        checkDuplicatedFriendShip(senderId, recevier.getId());
-        friendRepository.save(Friends.of(sender, recevier));
+        checkDuplicatedFriendShip(senderId, receiver.getId());
+        friendRepository.save(Friends.of(sender, receiver));
 
         notificationService.sendWithPush(
                 sender.getId(),
-                recevier,
+                receiver,
                 FRIEND_REQUEST,
                 String.format(FRIEND_REQUEST_MESSAGE, sender.getNickname()));
     }
@@ -58,13 +57,13 @@ public class FriendService {
     }
 
     @Transactional
-    public void updateFriendStatus(Long receiverId, FriendStatusUpdateReqeustDto dto) {
-        Friends friendShip = findBySenderIdAndReceiverId(dto.senderId(), receiverId);
+    public void updateFriendStatus(Long senderId, Long receiverId) {
+        Friends friendShip = findBySenderIdAndReceiverId(senderId, receiverId);
         friendShip.updateStatus();
     }
 
-    public void deleteFriend(Long memberId, Long receiverId) {
-        Friends friendShip = getFriendShip(memberId, receiverId);
+    public void deleteFriend(Long currentId, Long memberId) {
+        Friends friendShip = getFriendShip(currentId, memberId);
         friendRepository.delete(friendShip);
     }
 

--- a/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
+++ b/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
@@ -48,8 +48,8 @@ public class FriendService {
 //                String.format(FRIEND_REQUEST_MESSAGE, sender.getNickname()));
     }
 
-    public Slice<FriendsResponseDto> findFriendsListByMemberId(Long memberId, int page, int size) {
-        Pageable pageable = PageRequest.of(page, size);
+    public Slice<FriendsResponseDto> findFriendsListByMemberId(Long memberId, int pageNum, int pageSize) {
+        Pageable pageable = PageRequest.of(pageNum, pageSize);
 
         Slice<Friends> friendsList = friendRepository.findFriendsListByMemberId(memberId, pageable);
 

--- a/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
+++ b/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
@@ -8,6 +8,7 @@ import com.gachtaxi.domain.friend.exception.FriendNotExistsException;
 import com.gachtaxi.domain.friend.exception.FriendShipDoesNotSendMySelfException;
 import com.gachtaxi.domain.friend.exception.FriendShipExistsException;
 import com.gachtaxi.domain.friend.exception.FriendShipPendingException;
+import com.gachtaxi.domain.friend.mapper.FriendsMapper;
 import com.gachtaxi.domain.friend.repository.FriendRepository;
 import com.gachtaxi.domain.members.entity.Members;
 import com.gachtaxi.domain.members.service.MemberService;
@@ -15,9 +16,10 @@ import com.gachtaxi.domain.notification.service.NotificationService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Slf4j
 @Service
@@ -46,8 +48,12 @@ public class FriendService {
 //                String.format(FRIEND_REQUEST_MESSAGE, sender.getNickname()));
     }
 
-    public List<FriendsResponseDto> getFriendsList(Long memberId){
-        return friendRepository.findAcceptedFriendsByMemberId(memberId);
+    public Slice<FriendsResponseDto> findFriendsListByMemberId(Long memberId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+
+        Slice<Friends> friendsList = friendRepository.findFriendsListByMemberId(memberId, pageable);
+
+        return friendsList.map(f -> FriendsMapper.toResponseDto(f, memberId));
     }
 
     @Transactional

--- a/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
+++ b/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
@@ -62,6 +62,7 @@ public class FriendService {
         friendShip.updateStatus();
     }
 
+    @Transactional
     public void deleteFriend(Long currentId, Long memberId) {
         Friends friendShip = getFriendShip(currentId, memberId);
         friendRepository.delete(friendShip);
@@ -71,7 +72,7 @@ public class FriendService {
     * refactoring
     * */
 
-    public void checkDuplicatedFriendShip(Long senderId, Long receiverId) {
+    private void checkDuplicatedFriendShip(Long senderId, Long receiverId) {
         if(senderId.equals(receiverId)) { // 자기 자신한테 친구 요청을 보낼 경우
             throw new FriendShipDoesNotSendMySelfException();
         }

--- a/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
+++ b/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
@@ -1,9 +1,11 @@
 package com.gachtaxi.domain.friend.service;
 
 import com.gachtaxi.domain.friend.dto.request.FriendRequestDto;
+import com.gachtaxi.domain.friend.dto.request.FriendStatusUpdateReqeustDto;
 import com.gachtaxi.domain.friend.dto.response.FriendsResponseDto;
 import com.gachtaxi.domain.friend.entity.Friends;
 import com.gachtaxi.domain.friend.entity.enums.FriendStatus;
+import com.gachtaxi.domain.friend.exception.FriendNotExistsException;
 import com.gachtaxi.domain.friend.exception.FriendShipDoesNotSendMySelfException;
 import com.gachtaxi.domain.friend.exception.FriendShipExistsException;
 import com.gachtaxi.domain.friend.exception.FriendShipPendingException;
@@ -55,6 +57,11 @@ public class FriendService {
                 .toList();
     }
 
+    @Transactional
+    public void updateFriendStatus(Long receiverId, FriendStatusUpdateReqeustDto dto) {
+        Friends friendShip = findBySenderIdAndReceiverId(dto.senderId(), receiverId);
+        friendShip.updateStatus();
+    }
 
 
     public void checkDuplicatedFriendShip(Long senderId, Long receiverId) {
@@ -77,5 +84,15 @@ public class FriendService {
         return friendRepository.findAcceptedFriendsByMemberId(memberId);
     }
 
+    // A와 B 중 누가 sender이고 receiver인지 정확히 아는 경우 (ex Notification에 저장된 친구 요청)
+    public Friends findBySenderIdAndReceiverId(Long senderId, Long receiverId) {
+        return friendRepository.findBySenderIdAndReceiverId(senderId, receiverId)
+                .orElseThrow(FriendNotExistsException::new);
+    }
 
+    // A와 B 중 누가 sender이고 receiver인지 모르는 경우 (ex A와B가 친구인 지 확인할 때)
+    public Friends getFriendShip(Long senderId, Long receiverId) {
+        return friendRepository.findFriendShip(senderId, receiverId)
+                .orElseThrow(FriendNotExistsException::new);
+    }
 }

--- a/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
+++ b/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
@@ -35,7 +35,8 @@ public class FriendService {
     @Transactional
     public void sendFriendRequest(Long senderId, FriendRequestDto dto) {
         Members sender = memberService.findById(senderId);
-        Members receiver = memberService.findById(dto.memberId());
+        Members receiver = memberService.findByNickname(dto.nickName());
+
 
         checkDuplicatedFriendShip(senderId, receiver.getId());
         friendRepository.save(Friends.of(sender, receiver));
@@ -47,21 +48,8 @@ public class FriendService {
                 String.format(FRIEND_REQUEST_MESSAGE, sender.getNickname()));
     }
 
-//    public List<FriendsResponseDto> getFriendsList(Long memberId){
-//        List<Friends> friendsList = getAcceptedFriendsList(memberId);
-//
-//        return friendsList.stream()
-//                .map(friends -> FriendsMapper.toResponseDto(friends, memberId))
-//                .toList();
-//    }
-
     public List<FriendsResponseDto> getFriendsList(Long memberId){
         return friendRepository.findAcceptedFriendsByMemberId(memberId);
-//        List<Friends> friendsList = getAcceptedFriendsList(memberId);
-//
-//        return friendsList.stream()
-//                .map(friends -> FriendsMapper.toResponseDto(friends, memberId))
-//                .toList();
     }
 
     @Transactional
@@ -94,10 +82,6 @@ public class FriendService {
                     }
                 });
     }
-
-//    public List<Friends> getAcceptedFriendsList(Long memberId) {
-//        return friendRepository.findAcceptedFriendsByMemberId(memberId);
-//    }
 
     // A와 B 중 누가 sender이고 receiver인지 정확히 아는 경우 (ex Notification에 저장된 친구 요청)
     public Friends findBySenderIdAndReceiverId(Long senderId, Long receiverId) {

--- a/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
+++ b/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
@@ -8,7 +8,6 @@ import com.gachtaxi.domain.friend.exception.FriendNotExistsException;
 import com.gachtaxi.domain.friend.exception.FriendShipDoesNotSendMySelfException;
 import com.gachtaxi.domain.friend.exception.FriendShipExistsException;
 import com.gachtaxi.domain.friend.exception.FriendShipPendingException;
-import com.gachtaxi.domain.friend.mapper.FriendsMapper;
 import com.gachtaxi.domain.friend.repository.FriendRepository;
 import com.gachtaxi.domain.members.entity.Members;
 import com.gachtaxi.domain.members.service.MemberService;
@@ -48,12 +47,21 @@ public class FriendService {
                 String.format(FRIEND_REQUEST_MESSAGE, sender.getNickname()));
     }
 
-    public List<FriendsResponseDto> getFriendsList(Long memberId){
-        List<Friends> friendsList = getAcceptedFriendsList(memberId);
+//    public List<FriendsResponseDto> getFriendsList(Long memberId){
+//        List<Friends> friendsList = getAcceptedFriendsList(memberId);
+//
+//        return friendsList.stream()
+//                .map(friends -> FriendsMapper.toResponseDto(friends, memberId))
+//                .toList();
+//    }
 
-        return friendsList.stream()
-                .map(friends -> FriendsMapper.toResponseDto(friends, memberId))
-                .toList();
+    public List<FriendsResponseDto> getFriendsList(Long memberId){
+        return friendRepository.findAcceptedFriendsByMemberId(memberId);
+//        List<Friends> friendsList = getAcceptedFriendsList(memberId);
+//
+//        return friendsList.stream()
+//                .map(friends -> FriendsMapper.toResponseDto(friends, memberId))
+//                .toList();
     }
 
     @Transactional
@@ -87,9 +95,9 @@ public class FriendService {
                 });
     }
 
-    public List<Friends> getAcceptedFriendsList(Long memberId) {
-        return friendRepository.findAcceptedFriendsByMemberId(memberId);
-    }
+//    public List<Friends> getAcceptedFriendsList(Long memberId) {
+//        return friendRepository.findAcceptedFriendsByMemberId(memberId);
+//    }
 
     // A와 B 중 누가 sender이고 receiver인지 정확히 아는 경우 (ex Notification에 저장된 친구 요청)
     public Friends findBySenderIdAndReceiverId(Long senderId, Long receiverId) {

--- a/src/main/java/com/gachtaxi/domain/members/repository/MemberRepository.java
+++ b/src/main/java/com/gachtaxi/domain/members/repository/MemberRepository.java
@@ -20,5 +20,7 @@ public interface MemberRepository extends JpaRepository<Members, Long> {
 
     Optional<Members> findByNickname(String nickname);
 
+    Optional<Members> findByNicknameAndStatus(String nickname, UserStatus status);
+
     Optional<Members> findByEmailAndStatus(String email, UserStatus status);
 }

--- a/src/main/java/com/gachtaxi/domain/members/service/MemberService.java
+++ b/src/main/java/com/gachtaxi/domain/members/service/MemberService.java
@@ -86,6 +86,11 @@ public class MemberService {
                 .orElseThrow(MemberNotFoundException::new);
     }
 
+    public Members findByNickname(String nickname) {
+        return memberRepository.findByNicknameAndStatus(nickname, ACTIVE)
+                .orElseThrow(MemberNotFoundException::new);
+    }
+
     private void checkDuplicatedStudentNumber(Long studentNumber) {
         memberRepository.findByStudentNumber(studentNumber).ifPresent(m -> {
             throw new DuplicatedStudentNumberException();

--- a/src/main/java/com/gachtaxi/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/gachtaxi/global/config/PermitUrlConfig.java
@@ -22,7 +22,6 @@ public class PermitUrlConfig {
     public String[] getMemberUrl(){
         return new String[]{
                 "/auth/code/**",
-                "/api/friends",
                 "/api/friends/**"
         };
     }

--- a/src/main/java/com/gachtaxi/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/gachtaxi/global/config/PermitUrlConfig.java
@@ -22,6 +22,8 @@ public class PermitUrlConfig {
     public String[] getMemberUrl(){
         return new String[]{
                 "/auth/code/**",
+                "/api/friends",
+                "/api/friends/**"
         };
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #42 
Close #42 


## 🚀 작업 내용
> PR에서 작업한 내용을 설명

- [ ] 친구 엔티티 추가
- [ ] 친구 요청 API
- [ ] 친구 목록 조회 API
- [ ] 친구 수락 API
- [ ] 친구 거절 및 삭제 API

### 엔티티 구상

```java
public class Friends extends BaseEntity {

    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "sender_id")
    private Members sender;

    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "receiver_id")
    private Members receiver;

    @Builder.Default
    @Enumerated(EnumType.STRING)
    private FriendStatus status = PENDING;
}
```

친구 요청에서 sender와 receiver가 존재하므로 위와 같이 필드명을 정했습니다.

초기에 FriendsStatus를 PENDING, ACCEPTED, REJECTED 세 가지로 생각했습니다.
히지만 친구 요청 거절 시 바로 삭제할 예정이므로 친구 요청 거절은 친구 삭제 API와 같이 사용하도록 했습니다.

프론트 측에서 dto 필드명에 맞춰서 데이터를 보낼 때, 헷갈리지 않도록 dto 필드명은 memberId로 통일하고 백엔드단에서는 메서드 매개인자나 변수에서 sender와 receiver를 적절히 사용하고자 했습니다.

### Fetch Join 

친구 목록을 보여줄 때 
Members sender와 Members receiver의 id, nickname, profile, Gender 정보를 반환해줘야 합니다.
지연 로딩을 사용하더라도 각 List에 담긴 여러 Friends를 사용하는 시점에 추가 쿼리가 나가게 되므로, 페치 조인을 사용했습니다.

### Friends 엔티티에 nickname, profile, gender 정보를 함께 저장한다면?
사용자의 닉네임과 프로필 사진이 변경 될 때 마다 해당 사용자가 포함된 Friends 데이터를 찾아 변경해줘야 하므로 비효율적입니다!

### FCM 알람 테스트

성공했습니다.



## 📸 스크린샷

### 친구 요청 성공 시 + FCM 알람 테스트 성공
![image](https://github.com/user-attachments/assets/9f3a5e0e-79f4-4176-ba1a-1a5e06aafd53)

### 친구 조회 시
테스트할 때 ResponseDto에 Gender가 포함되어있지 않아서 사진 상 없지만, Gender가 응답에 포함되도록 수정했습니다.
![image](https://github.com/user-attachments/assets/0e3bd6d3-d331-4af5-9b32-159a27da53c1)

### 친구 수락 시
![image](https://github.com/user-attachments/assets/1a698177-0c82-486f-a589-d7f5978627d7)

### 친구 요청 거절 및 삭제
![image](https://github.com/user-attachments/assets/3164bff5-ec9f-4dd0-8cd4-0a24fb6825da)




## 📢 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성

### 2025.01.31 변경사항
초창기 친구 요청을 보낼 때, receiverId를 받도록 구현했는데, 피그마를 참고하여 
`받는 이의 닉네임`을 받아 친구 요청을 보내도록 수정했습니다.
![image](https://github.com/user-attachments/assets/24f942ff-48db-40fe-8ffe-79321af43d82)

### 2025.02.01 변경 사항
1. 강혁님이 구현하신 알림 페이로드 코드를 병합 후 코드 수정해서 오류 없도록 반영했습니다.
2. 추가로 프론트측에서 Pageable 반환 시 데이터 양이 너무 많아 간소화했습니다.

