### PR TITLE
Feat #60 사용자 관련 api 구현

### DIFF
--- a/src/main/java/com/gachtaxi/domain/members/controller/MemberController.java
+++ b/src/main/java/com/gachtaxi/domain/members/controller/MemberController.java
@@ -10,13 +10,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-import static com.gachtaxi.domain.members.controller.ResponseMessage.FCM_TOKEN_UPDATE_SUCCESS;
-import static com.gachtaxi.domain.members.controller.ResponseMessage.MEMBER_INFO_UPDATE;
+import static com.gachtaxi.domain.members.controller.ResponseMessage.*;
 import static org.springframework.http.HttpStatus.OK;
 
 @Tag(name = "MEMBER")
@@ -34,6 +30,12 @@ public class MemberController {
         memberService.updateFcmToken(memberId, request);
 
         return ApiResponse.response(OK, FCM_TOKEN_UPDATE_SUCCESS.getMessage());
+    }
+
+    @GetMapping("/info")
+    public ApiResponse<MemberResponseDto> getMemberInfo(@CurrentMemberId Long currentId) {
+        MemberResponseDto response = memberService.getMember(currentId);
+        return ApiResponse.response(OK, MEMBER_INFO_RESPONSE.getMessage(), response);
     }
 
     @PatchMapping("/info")

--- a/src/main/java/com/gachtaxi/domain/members/controller/MemberController.java
+++ b/src/main/java/com/gachtaxi/domain/members/controller/MemberController.java
@@ -33,7 +33,7 @@ public class MemberController {
     }
 
     @GetMapping("/info")
-    public ApiResponse<MemberResponseDto> getMemberInfo(@CurrentMemberId Long currentId) {
+    public ApiResponse<MemberResponseDto> memberInfoDetails(@CurrentMemberId Long currentId) {
         MemberResponseDto response = memberService.getMember(currentId);
         return ApiResponse.response(OK, MEMBER_INFO_RESPONSE.getMessage(), response);
     }

--- a/src/main/java/com/gachtaxi/domain/members/controller/MemberController.java
+++ b/src/main/java/com/gachtaxi/domain/members/controller/MemberController.java
@@ -1,6 +1,8 @@
 package com.gachtaxi.domain.members.controller;
 
 import com.gachtaxi.domain.members.dto.request.FcmTokenRequest;
+import com.gachtaxi.domain.members.dto.request.MemberInfoRequestDto;
+import com.gachtaxi.domain.members.dto.response.MemberResponseDto;
 import com.gachtaxi.domain.members.service.MemberService;
 import com.gachtaxi.global.auth.jwt.annotation.CurrentMemberId;
 import com.gachtaxi.global.common.response.ApiResponse;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static com.gachtaxi.domain.members.controller.ResponseMessage.FCM_TOKEN_UPDATE_SUCCESS;
+import static com.gachtaxi.domain.members.controller.ResponseMessage.MEMBER_INFO_UPDATE;
 import static org.springframework.http.HttpStatus.OK;
 
 @Tag(name = "MEMBER")
@@ -31,5 +34,14 @@ public class MemberController {
         memberService.updateFcmToken(memberId, request);
 
         return ApiResponse.response(OK, FCM_TOKEN_UPDATE_SUCCESS.getMessage());
+    }
+
+    @PatchMapping("/info")
+    public ApiResponse<MemberResponseDto> memberInfoModify(
+            @CurrentMemberId Long currentId,
+            @RequestBody MemberInfoRequestDto dto
+    ) {
+        MemberResponseDto response = memberService.updateMemberInfo(currentId, dto);
+        return ApiResponse.response(OK, MEMBER_INFO_UPDATE.getMessage(), response);
     }
 }

--- a/src/main/java/com/gachtaxi/domain/members/controller/ResponseMessage.java
+++ b/src/main/java/com/gachtaxi/domain/members/controller/ResponseMessage.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum ResponseMessage {
     // MemberController
     REGISTER_SUCCESS("회원가입에 성공했습니다."),
+    MEMBER_INFO_UPDATE("유저 정보를 성공적으로 수정했습니다!"),
     FCM_TOKEN_UPDATE_SUCCESS("FCM 토큰 업데이트에 성공했습니다."),
 
     // AuthController

--- a/src/main/java/com/gachtaxi/domain/members/controller/ResponseMessage.java
+++ b/src/main/java/com/gachtaxi/domain/members/controller/ResponseMessage.java
@@ -9,6 +9,7 @@ public enum ResponseMessage {
     // MemberController
     REGISTER_SUCCESS("회원가입에 성공했습니다."),
     MEMBER_INFO_UPDATE("유저 정보를 성공적으로 수정했습니다!"),
+    MEMBER_INFO_RESPONSE("유저 정보를 반환합니다."),
     FCM_TOKEN_UPDATE_SUCCESS("FCM 토큰 업데이트에 성공했습니다."),
 
     // AuthController

--- a/src/main/java/com/gachtaxi/domain/members/dto/request/MemberInfoRequestDto.java
+++ b/src/main/java/com/gachtaxi/domain/members/dto/request/MemberInfoRequestDto.java
@@ -1,8 +1,10 @@
 package com.gachtaxi.domain.members.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+
 public record MemberInfoRequestDto(
-        String profilePicture,
-        String nickName,
-        String accountNumber
+        @NotNull String profilePicture,
+        @NotNull String nickName,
+        @NotNull String accountNumber
 ) {
 }

--- a/src/main/java/com/gachtaxi/domain/members/dto/request/MemberInfoRequestDto.java
+++ b/src/main/java/com/gachtaxi/domain/members/dto/request/MemberInfoRequestDto.java
@@ -1,0 +1,8 @@
+package com.gachtaxi.domain.members.dto.request;
+
+public record MemberInfoRequestDto(
+        String profilePicture,
+        String nickName,
+        String accountNumber
+) {
+}

--- a/src/main/java/com/gachtaxi/domain/members/dto/request/MemberIntegrationRequestDto.java
+++ b/src/main/java/com/gachtaxi/domain/members/dto/request/MemberIntegrationRequestDto.java
@@ -1,9 +1,0 @@
-package com.gachtaxi.domain.members.dto.request;
-
-public record MemberIntegrationRequestDto(
-        String email,
-        String authCode,
-        Long kakaoId,
-        String googleId
-) {
-}

--- a/src/main/java/com/gachtaxi/domain/members/dto/response/MemberResponseDto.java
+++ b/src/main/java/com/gachtaxi/domain/members/dto/response/MemberResponseDto.java
@@ -13,7 +13,8 @@ public record MemberResponseDto(
         String profilePicture,
         String email,
         String role,
-        Gender gender
+        Gender gender,
+        String accountNumber
 ) {
     public static MemberResponseDto from(Members members) {
         return MemberResponseDto.builder()
@@ -25,6 +26,7 @@ public record MemberResponseDto(
                 .email(members.getEmail())
                 .role(members.getRole().name())
                 .gender(members.getGender())
+                .accountNumber(members.getAccountNumber())
                 .build();
     }
 }

--- a/src/main/java/com/gachtaxi/domain/members/entity/Members.java
+++ b/src/main/java/com/gachtaxi/domain/members/entity/Members.java
@@ -1,21 +1,22 @@
 package com.gachtaxi.domain.members.entity;
 
 import com.gachtaxi.domain.matching.common.entity.MatchingRoom;
-import com.gachtaxi.domain.members.dto.request.UserSignUpRequestDto;
 import com.gachtaxi.domain.members.dto.request.MemberAgreementRequestDto;
+import com.gachtaxi.domain.members.dto.request.MemberInfoRequestDto;
 import com.gachtaxi.domain.members.dto.request.MemberSupplmentRequestDto;
 import com.gachtaxi.domain.members.entity.enums.Gender;
 import com.gachtaxi.domain.members.entity.enums.Role;
 import com.gachtaxi.domain.members.entity.enums.UserStatus;
 import com.gachtaxi.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
-import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.ColumnDefault;
+
+import java.util.Objects;
 
 @Getter
 @Entity
@@ -41,6 +42,9 @@ public class Members extends BaseEntity {
 
     @Column(name = "phone_number", unique = true) // 피그마 참고, 일단 null 허용
     private String phoneNumber;
+
+    @Column(name = "account_number", unique = true)
+    private String accountNumber;
 
     @Column(name = "kakao_id", unique = true)
     private Long kakaoId;
@@ -111,6 +115,12 @@ public class Members extends BaseEntity {
 
     public void updateGoogleId(String googleId) {
         this.googleId = googleId;
+    }
+
+    public void updateMemberInfo(MemberInfoRequestDto dto) {
+        this.profilePicture = dto.profilePicture();
+        this.nickname = dto.nickName();
+        this.accountNumber = dto.accountNumber();
     }
 
     public void updateAgreement(MemberAgreementRequestDto dto) {

--- a/src/main/java/com/gachtaxi/domain/members/service/MemberService.java
+++ b/src/main/java/com/gachtaxi/domain/members/service/MemberService.java
@@ -28,6 +28,11 @@ public class MemberService {
         return InactiveMemberDto.of(tmpMember);
     }
 
+    public MemberResponseDto getMember(Long currentId){
+        Members members = findById(currentId);
+        return MemberResponseDto.from(members);
+    }
+
     @Transactional
     public MemberResponseDto updateMemberInfo(Long currentId, MemberInfoRequestDto dto){
         Members member = findById(currentId);

--- a/src/main/java/com/gachtaxi/domain/members/service/MemberService.java
+++ b/src/main/java/com/gachtaxi/domain/members/service/MemberService.java
@@ -1,9 +1,6 @@
 package com.gachtaxi.domain.members.service;
 
-import com.gachtaxi.domain.members.dto.request.FcmTokenRequest;
-import com.gachtaxi.domain.members.dto.request.InactiveMemberDto;
-import com.gachtaxi.domain.members.dto.request.MemberAgreementRequestDto;
-import com.gachtaxi.domain.members.dto.request.MemberSupplmentRequestDto;
+import com.gachtaxi.domain.members.dto.request.*;
 import com.gachtaxi.domain.members.dto.response.MemberResponseDto;
 import com.gachtaxi.domain.members.entity.Members;
 import com.gachtaxi.domain.members.exception.DuplicatedNickNameException;
@@ -29,6 +26,14 @@ public class MemberService {
         Members tmpMember = Members.ofKakaoId(kakaoId);
         memberRepository.save(tmpMember);
         return InactiveMemberDto.of(tmpMember);
+    }
+
+    @Transactional
+    public MemberResponseDto updateMemberInfo(Long currentId, MemberInfoRequestDto dto){
+        Members member = findById(currentId);
+        member.updateMemberInfo(dto);
+
+        return MemberResponseDto.from(member);
     }
 
     @Transactional


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #59 
Close #59 


## 🚀 작업 내용
> PR에서 작업한 내용을 설명

- [ ] 사용자 정보 반환 API
- [ ] 사용자 정보 수정 API

토큰으로 추출한 memberId로 사용자 정보를 반환하는 API를 구현했습니다.
또한 사용자 정보를 수정하는 API를 구현했습니다.

## 📸 스크린샷

### 사용자 정보 반환 API
![image](https://github.com/user-attachments/assets/a816563a-2b1d-4d6e-9979-395e08e89f7f)

### 사용자 정보 수정 API
![image](https://github.com/user-attachments/assets/08f4cc92-e518-41a4-9634-5d7182f25024)


## 📢 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성

간단한 작업이라 크게 문제 될 부분은 없어 보입니다!
컨트롤러에서 보다 더 나은 메서드 명이 있을까요??