### PR TITLE
Refactor #62 알림 dto 간소화 및 mongodb로 이전

### DIFF
--- a/src/main/java/com/gachtaxi/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/gachtaxi/domain/notification/controller/NotificationController.java
@@ -1,14 +1,13 @@
 package com.gachtaxi.domain.notification.controller;
 
 import com.gachtaxi.domain.notification.dto.response.NotificationInfoResponse;
-import com.gachtaxi.domain.notification.dto.response.NotificationResponse;
+import com.gachtaxi.domain.notification.dto.response.NotificationListResponse;
 import com.gachtaxi.domain.notification.service.NotificationService;
 import com.gachtaxi.global.auth.jwt.annotation.CurrentMemberId;
 import com.gachtaxi.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Slice;
 import org.springframework.web.bind.annotation.*;
 
 import static com.gachtaxi.domain.notification.controller.ResponseMessage.NOTIFICATION_DELETE_SUCCESS;
@@ -25,10 +24,10 @@ public class NotificationController {
 
     @GetMapping
     @Operation(summary = "전체 알림을 조회하는 API입니다.")
-    public ApiResponse<Slice<NotificationResponse>> getNotifications(@CurrentMemberId Long memberId,
-                                                                     @RequestParam int pageNum,
-                                                                     @RequestParam int pageSize) {
-        Slice<NotificationResponse> response = notificationService.getNotifications(memberId, pageNum, pageSize);
+    public ApiResponse<NotificationListResponse> getNotifications(@CurrentMemberId Long memberId,
+                                                                  @RequestParam int pageNum,
+                                                                  @RequestParam int pageSize) {
+        NotificationListResponse response = notificationService.getNotifications(memberId, pageNum, pageSize);
 
         return ApiResponse.response(OK, NOTIFICATION_GET_SUCCESS.getMessage(), response);
     }

--- a/src/main/java/com/gachtaxi/domain/notification/dto/response/NotificationListResponse.java
+++ b/src/main/java/com/gachtaxi/domain/notification/dto/response/NotificationListResponse.java
@@ -1,0 +1,12 @@
+package com.gachtaxi.domain.notification.dto.response;
+
+import java.util.List;
+
+public record NotificationListResponse(
+        List<NotificationResponse> response,
+        NotificationPageableResponse pageable
+) {
+    public static NotificationListResponse of(List<NotificationResponse> response, NotificationPageableResponse pageable) {
+        return new NotificationListResponse(response, pageable);
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/notification/dto/response/NotificationPageableResponse.java
+++ b/src/main/java/com/gachtaxi/domain/notification/dto/response/NotificationPageableResponse.java
@@ -1,0 +1,22 @@
+package com.gachtaxi.domain.notification.dto.response;
+
+import com.gachtaxi.domain.notification.entity.Notification;
+import lombok.Builder;
+import org.springframework.data.domain.Slice;
+
+@Builder
+public record NotificationPageableResponse(
+        int pageNumber,
+        int pageSize,
+        int numberOfElements,
+        boolean last
+) {
+    public static NotificationPageableResponse from(Slice<Notification> slice) {
+        return NotificationPageableResponse.builder()
+                .pageNumber(slice.getNumber())
+                .pageSize(slice.getSize())
+                .numberOfElements(slice.getNumberOfElements())
+                .last(slice.isLast())
+                .build();
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/gachtaxi/domain/notification/dto/response/NotificationResponse.java
@@ -1,7 +1,6 @@
 package com.gachtaxi.domain.notification.dto.response;
 
 import com.gachtaxi.domain.notification.entity.Notification;
-import com.gachtaxi.domain.notification.entity.enums.NotificationStatus;
 import com.gachtaxi.domain.notification.entity.enums.NotificationType;
 import lombok.Builder;
 
@@ -13,7 +12,6 @@ public record NotificationResponse(
         long senderId,
         long receiverId,
         NotificationType type,
-        NotificationStatus status,
         String title,
         String content,
         LocalDateTime createdAt
@@ -24,7 +22,6 @@ public record NotificationResponse(
                 .senderId(notification.getSenderId())
                 .receiverId(notification.getReceiverId())
                 .type(notification.getType())
-                .status(notification.getStatus())
                 .title(notification.getTitle())
                 .content(notification.getContent())
                 .createdAt(notification.getCreateDate())

--- a/src/main/java/com/gachtaxi/domain/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/gachtaxi/domain/notification/dto/response/NotificationResponse.java
@@ -2,28 +2,27 @@ package com.gachtaxi.domain.notification.dto.response;
 
 import com.gachtaxi.domain.notification.entity.Notification;
 import com.gachtaxi.domain.notification.entity.enums.NotificationType;
+import com.gachtaxi.domain.notification.entity.payload.NotificationPayload;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
 
 @Builder
 public record NotificationResponse(
-        long notificationId,
-        long senderId,
+        String notificationId,
         long receiverId,
         NotificationType type,
-        String title,
         String content,
+        NotificationPayload payload,
         LocalDateTime createdAt
 ) {
     public static NotificationResponse from(Notification notification) {
         return NotificationResponse.builder()
                 .notificationId(notification.getId())
-                .senderId(notification.getSenderId())
                 .receiverId(notification.getReceiverId())
                 .type(notification.getType())
-                .title(notification.getTitle())
                 .content(notification.getContent())
+                .payload(notification.getPayload())
                 .createdAt(notification.getCreateDate())
                 .build();
     }

--- a/src/main/java/com/gachtaxi/domain/notification/entity/Notification.java
+++ b/src/main/java/com/gachtaxi/domain/notification/entity/Notification.java
@@ -2,61 +2,51 @@ package com.gachtaxi.domain.notification.entity;
 
 import com.gachtaxi.domain.notification.entity.enums.NotificationStatus;
 import com.gachtaxi.domain.notification.entity.enums.NotificationType;
-import com.gachtaxi.global.common.entity.BaseEntity;
+import com.gachtaxi.domain.notification.entity.payload.NotificationPayload;
 import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.LocalDateTime;
 
 import static com.gachtaxi.domain.notification.entity.enums.NotificationStatus.*;
 
 @Getter
-@Entity
+@Document(collection = "notifications")
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Notification extends BaseEntity {
+public class Notification {
 
-    private Long senderId;
+    @Id
+    private String id;
 
     private Long receiverId;
 
     @Enumerated(EnumType.STRING)
     private NotificationType type;
 
-    private String title;
-
     @Column(columnDefinition = "text")
     private String content;
+
+    private NotificationPayload payload;
 
     @Builder.Default
     @Enumerated(EnumType.STRING)
     private NotificationStatus status = UNREAD;
 
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createDate;
+
     private LocalDateTime readAt;
-
-    public static Notification of(Long senderId, Long receiverId, NotificationType type, String content) {
-        return Notification.builder()
-                .senderId(senderId)
-                .receiverId(receiverId)
-                .type(type)
-                .content(content)
-                .build();
-    }
-
-    public static Notification of(Long receiverId, NotificationType type, String content) {
-        return Notification.builder()
-                .receiverId(receiverId)
-                .type(type)
-                .content(content)
-                .build();
-    }
 
     public void read() {
         this.status = READ;
@@ -65,5 +55,14 @@ public class Notification extends BaseEntity {
 
     public void failToSend() {
         this.status = UNSENT;
+    }
+
+    public static Notification of(Long receiverId, NotificationType type, String content, NotificationPayload payload) {
+        return Notification.builder()
+                .receiverId(receiverId)
+                .type(type)
+                .content(content)
+                .payload(payload)
+                .build();
     }
 }

--- a/src/main/java/com/gachtaxi/domain/notification/entity/enums/NotificationType.java
+++ b/src/main/java/com/gachtaxi/domain/notification/entity/enums/NotificationType.java
@@ -1,5 +1,5 @@
 package com.gachtaxi.domain.notification.entity.enums;
 
 public enum NotificationType {
-    CHAT, MATCH_SUCCESS, MATCH_FAILURE, MATCH_FINISH, FRIEND_REQUEST
+    MATCH_START, MATCH_FINISH, FRIEND_REQUEST
 }

--- a/src/main/java/com/gachtaxi/domain/notification/entity/payload/FriendRequestPayload.java
+++ b/src/main/java/com/gachtaxi/domain/notification/entity/payload/FriendRequestPayload.java
@@ -1,0 +1,16 @@
+package com.gachtaxi.domain.notification.entity.payload;
+
+import com.gachtaxi.domain.notification.entity.enums.NotificationStatus;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FriendRequestPayload extends NotificationPayload {
+
+    @Builder.Default
+    private NotificationStatus notificationStatus = NotificationStatus.PENDING;
+
+    private Long senderId;
+}

--- a/src/main/java/com/gachtaxi/domain/notification/entity/payload/FriendRequestPayload.java
+++ b/src/main/java/com/gachtaxi/domain/notification/entity/payload/FriendRequestPayload.java
@@ -1,7 +1,8 @@
 package com.gachtaxi.domain.notification.entity.payload;
 
-import com.gachtaxi.domain.notification.entity.enums.NotificationStatus;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Getter
@@ -9,8 +10,8 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FriendRequestPayload extends NotificationPayload {
 
-    @Builder.Default
-    private NotificationStatus notificationStatus = NotificationStatus.PENDING;
+//    @Builder.Default
+//    private FriendStatus status = FriendStatus.PENDING;
 
     private Long senderId;
 }

--- a/src/main/java/com/gachtaxi/domain/notification/entity/payload/FriendRequestPayload.java
+++ b/src/main/java/com/gachtaxi/domain/notification/entity/payload/FriendRequestPayload.java
@@ -14,4 +14,8 @@ public class FriendRequestPayload extends NotificationPayload {
 //    private FriendStatus status = FriendStatus.PENDING;
 
     private Long senderId;
+
+    public static FriendRequestPayload from(Long senderId) {
+        return FriendRequestPayload.builder().senderId(senderId).build();
+    }
 }

--- a/src/main/java/com/gachtaxi/domain/notification/entity/payload/MatchingPayload.java
+++ b/src/main/java/com/gachtaxi/domain/notification/entity/payload/MatchingPayload.java
@@ -1,0 +1,15 @@
+package com.gachtaxi.domain.notification.entity.payload;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MatchingPayload extends NotificationPayload {
+    private String startLocationName;
+
+    private String endLocationName;
+}

--- a/src/main/java/com/gachtaxi/domain/notification/entity/payload/MatchingPayload.java
+++ b/src/main/java/com/gachtaxi/domain/notification/entity/payload/MatchingPayload.java
@@ -12,4 +12,11 @@ public class MatchingPayload extends NotificationPayload {
     private String startLocationName;
 
     private String endLocationName;
+
+    public static MatchingPayload of(String startLocationName, String endLocationName) {
+        return MatchingPayload.builder()
+                .startLocationName(startLocationName)
+                .endLocationName(endLocationName)
+                .build();
+    }
 }

--- a/src/main/java/com/gachtaxi/domain/notification/entity/payload/NotificationPayload.java
+++ b/src/main/java/com/gachtaxi/domain/notification/entity/payload/NotificationPayload.java
@@ -1,0 +1,11 @@
+package com.gachtaxi.domain.notification.entity.payload;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class NotificationPayload {
+
+}

--- a/src/main/java/com/gachtaxi/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/gachtaxi/domain/notification/repository/NotificationRepository.java
@@ -4,9 +4,9 @@ import com.gachtaxi.domain.notification.entity.Notification;
 import com.gachtaxi.domain.notification.entity.enums.NotificationStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface NotificationRepository extends JpaRepository<Notification, Long> {
+public interface NotificationRepository extends MongoRepository<Notification, Long> {
 
     Integer countAllByReceiverIdAndStatus(Long receiverId, NotificationStatus status);
 

--- a/src/main/java/com/gachtaxi/global/config/FirebaseConfig.java
+++ b/src/main/java/com/gachtaxi/global/config/FirebaseConfig.java
@@ -9,6 +9,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -23,9 +25,7 @@ public class FirebaseConfig {
     public void initialize() {
 
         try {
-            ClassPathResource resource = new ClassPathResource(adminSdkPath);
-
-            InputStream inputStream = resource.getInputStream();
+            InputStream inputStream = getInputStream(adminSdkPath);
 
             FirebaseOptions options = FirebaseOptions.builder()
                     .setCredentials(GoogleCredentials.fromStream(inputStream))
@@ -38,6 +38,14 @@ public class FirebaseConfig {
 
         } catch (IOException e) {
             log.warn("Firebase 설정 중 예외 발생", e);
+        }
+    }
+
+    private InputStream getInputStream(String path) throws IOException {
+        if (new File(path).exists()) {
+            return new FileInputStream(path);
+        } else {
+            return new ClassPathResource(path).getInputStream();
         }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #52 
Close #


## 🚀 작업 내용
- 프론트 측 요구사항에 맞게 dto 일부를 간소화했습니다
- 알림 확장과 현재 요구사항 반영을 위해 mongodb로 이전했습니다
- 추상 클래스인 NotificationPayload를 상속하는 알림별 추가 데이터를 구현해 nosql의 장점에 맞게 저장을 했습니다.
```
[
  {
    "_id": {"$oid": "679c6d083afd022e8c4aeb09"},
    "_class": "com.gachtaxi.domain.notification.entity.Notification",
    "content": "매칭 테스트",
    "createDate": {"$date": "2025-01-31T06:26:16.413Z"},
    "payload": {
      "startLocationName": "가천대학교 정문",
      "endLocationName": "AI 공학관",
      "_class": "com.gachtaxi.domain.notification.entity.payload.MatchingPayload"
    },
    "readAt": {"$date": "2025-01-31T06:37:04.513Z"},
    "receiverId": 1,
    "status": "READ",
    "type": "MATCH_START"
  }
]
```
- 응답 반환의 경우 payload는 dto로 변환하지 않았습니다. payload 자체가 "알림별 추가 정보"의 목적으로 사용하기 때문에 클라이언트 측으로 넘겨줄 때 필터링할 데이터가 없다고 판단했고, 타입을 검증하면서까지 변환할 필요를 느끼지 못했습니다.
- FriendRequestPayload의 주석처리된 부분은 친구 pr이 머지되면 해제할 계획입니다.
- 알림을 보낼 때는 호출하는 쪽. 즉 친구면 FriendService, 채팅이면 chattingService에서 각 알림에 필요한 추가 데이터인 Payload를 생성해서 sendWithPush/sendWithoutPush에 함께 동봉해주시면 됩니다. 타입별 payload의 검증은 아직 추가하지 않았는데, 차후에 필요성이 느껴진다면 구현하도록 하겠습니다
## 📸 스크린샷
<img width="405" alt="image" src="https://github.com/user-attachments/assets/fdd771fd-84f8-4149-bba2-0cffac6a30a0" />


## 📢 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
