### PR TITLE
Feat/#63/수동매칭 CRUD 구현

### DIFF
--- a/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MatchingAlgorithmService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MatchingAlgorithmService.java
@@ -1,11 +1,9 @@
 package com.gachtaxi.domain.matching.algorithm.service;
 
 import com.gachtaxi.domain.matching.algorithm.dto.FindRoomResult;
-import com.gachtaxi.domain.matching.common.entity.MatchingRoom;
 import com.gachtaxi.domain.matching.common.entity.enums.Tags;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.domain.Page;
 
 public interface MatchingAlgorithmService {
 
@@ -21,13 +19,4 @@ public interface MatchingAlgorithmService {
    * @return Optional<FindRoomResult> - 매칭 가능한 방 정보가 있으면 값이 있고, 없으면 empty
    */
   Optional<FindRoomResult> findRoom(Long userId, double startLongitude, double startLatitude, double destinationLongitude, double destinationLatitude, List<Tags> criteria);
-
-  /**
-   * 전체 매칭 방을 페이지 단위로 조회
-   *
-   * @param pageNumber 페이지 번호 (0부터 시작)
-   * @param pageSize   한 페이지에 포함될 매칭 방의 개수
-   * @return Page<MatchingRoom> - 페이지별 매칭 방 정보
-   */
-  Page<MatchingRoom> findMatchingRooms(int pageNumber, int pageSize);
 }

--- a/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MatchingAlgorithmServiceImpl.java
+++ b/src/main/java/com/gachtaxi/domain/matching/algorithm/service/MatchingAlgorithmServiceImpl.java
@@ -4,16 +4,12 @@ import com.gachtaxi.domain.matching.algorithm.dto.FindRoomResult;
 import com.gachtaxi.domain.matching.common.entity.MatchingRoom;
 import com.gachtaxi.domain.matching.common.entity.enums.Tags;
 import com.gachtaxi.domain.matching.common.exception.AlreadyInMatchingRoomException;
-import com.gachtaxi.domain.matching.common.exception.PageNotFoundException;
 import com.gachtaxi.domain.matching.common.repository.MatchingRoomRepository;
 import com.gachtaxi.domain.members.entity.Members;
 import com.gachtaxi.domain.members.service.MemberService;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -72,16 +68,4 @@ public class MatchingAlgorithmServiceImpl implements MatchingAlgorithmService {
      */
     return Optional.empty();
   }
-  @Override
-  public Page<MatchingRoom> findMatchingRooms(int pageNumber, int pageSize) {
-
-    if (pageNumber < 0) {
-      throw new PageNotFoundException();
-    }
-
-    PageRequest pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "id"));
-
-    return matchingRoomRepository.findAll(pageable);
-  }
-
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
@@ -5,9 +5,9 @@ import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.JOI
 import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.LEAVE_MANUAL_MATCHING_ROOM_SUCCESS;
 
 import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingJoinRequest;
-import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingLeaveRequest;
 import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingRequest;
 import com.gachtaxi.domain.matching.common.service.ManualMatchingService;
+import com.gachtaxi.global.auth.jwt.annotation.CurrentMemberId;
 import com.gachtaxi.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -15,6 +15,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,7 +32,7 @@ public class ManualMatchingController {
     private final ManualMatchingService manualMatchingService;
 
     @Operation(summary = "수동 매칭방 생성")
-    @PostMapping("/create")
+    @PostMapping
     public ApiResponse<Long> createManualMatchingRoom(@Valid @RequestBody ManualMatchingRequest request) {
         Long roomId = manualMatchingService.createManualMatchingRoom(request);
         return ApiResponse.response(HttpStatus.OK, CREATE_MANUAL_MATCHING_ROOM_SUCCESS.getMessage(), roomId);
@@ -38,15 +40,15 @@ public class ManualMatchingController {
 
     @Operation(summary = "수동 매칭방 참여")
     @PostMapping("/join")
-    public ApiResponse<Void> joinManualMatchingRoom(@Valid @RequestBody ManualMatchingJoinRequest request) {
-        manualMatchingService.joinManualMatchingRoom(request.userId(), request.roomId());
+    public ApiResponse<Void> joinManualMatchingRoom(@CurrentMemberId Long userId, @Valid @RequestBody ManualMatchingJoinRequest request) {
+        manualMatchingService.joinManualMatchingRoom(userId, request.roomId());
         return ApiResponse.response(HttpStatus.OK, JOIN_MANUAL_MATCHING_ROOM_SUCCESS.getMessage());
     }
 
     @Operation(summary = "수동 매칭방 퇴장 (방 삭제 포함)")
-    @PostMapping("/leave")
-    public ApiResponse<Void> leaveManualMatchingRoom(@Valid @RequestBody ManualMatchingLeaveRequest request) {
-        manualMatchingService.leaveManualMatchingRoom(request.userId(), request.roomId());
+    @PatchMapping("/exit/{roomId}")
+    public ApiResponse<Void> leaveManualMatchingRoom(@CurrentMemberId Long userId, @PathVariable Long roomId) {
+        manualMatchingService.leaveManualMatchingRoom(userId, roomId);
         return ApiResponse.response(HttpStatus.OK, LEAVE_MANUAL_MATCHING_ROOM_SUCCESS.getMessage());
     }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
@@ -2,8 +2,10 @@ package com.gachtaxi.domain.matching.common.controller;
 
 import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.CREATE_MANUAL_MATCHING_ROOM_SUCCESS;
 import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.JOIN_MANUAL_MATCHING_ROOM_SUCCESS;
+import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.LEAVE_MANUAL_MATCHING_ROOM_SUCCESS;
 
 import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingJoinRequest;
+import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingLeaveRequest;
 import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingRequest;
 import com.gachtaxi.domain.matching.common.service.ManualMatchingService;
 import com.gachtaxi.global.common.response.ApiResponse;
@@ -39,5 +41,12 @@ public class ManualMatchingController {
     public ApiResponse<Void> joinManualMatchingRoom(@Valid @RequestBody ManualMatchingJoinRequest request) {
         manualMatchingService.joinManualMatchingRoom(request.userId(), request.roomId());
         return ApiResponse.response(HttpStatus.OK, JOIN_MANUAL_MATCHING_ROOM_SUCCESS.getMessage());
+    }
+
+    @Operation(summary = "수동 매칭방 퇴장 (방 삭제 포함)")
+    @PostMapping("/leave")
+    public ApiResponse<Void> leaveManualMatchingRoom(@Valid @RequestBody ManualMatchingLeaveRequest request) {
+        manualMatchingService.leaveManualMatchingRoom(request.userId(), request.roomId());
+        return ApiResponse.response(HttpStatus.OK, LEAVE_MANUAL_MATCHING_ROOM_SUCCESS.getMessage());
     }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
@@ -1,0 +1,34 @@
+package com.gachtaxi.domain.matching.common.controller;
+
+import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.CREATE_MANUAL_MATCHING_ROOM_SUCCESS;
+import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingRequest;
+import com.gachtaxi.domain.matching.common.service.ManualMatchingService;
+import com.gachtaxi.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "MANUAL", description = "수동매칭 API")
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/matching/manual")
+public class ManualMatchingController {
+
+    private final ManualMatchingService manualMatchingService;
+
+    @Operation(summary = "수동 매칭방 생성")
+    @PostMapping("/create")
+    public ApiResponse<Long> createManualMatchingRoom(@Valid @RequestBody ManualMatchingRequest request) {
+        Long roomId = manualMatchingService.createManualMatchingRoom(request);
+        return ApiResponse.response(HttpStatus.OK, CREATE_MANUAL_MATCHING_ROOM_SUCCESS.getMessage(), roomId);
+    }
+
+}

--- a/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
@@ -30,7 +30,7 @@ public class ManualMatchingController {
     private final ManualMatchingService manualMatchingService;
 
     @Operation(summary = "수동 매칭방 생성")
-    @PostMapping
+    @PostMapping("/creation")
     public ApiResponse<Long> createManualMatchingRoom(@Valid @RequestBody ManualMatchingRequest request) {
         Long roomId = manualMatchingService.createManualMatchingRoom(request);
         return ApiResponse.response(HttpStatus.OK, CREATE_MANUAL_MATCHING_ROOM_SUCCESS.getMessage(), roomId);

--- a/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
@@ -1,6 +1,9 @@
 package com.gachtaxi.domain.matching.common.controller;
 
 import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.CREATE_MANUAL_MATCHING_ROOM_SUCCESS;
+import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.JOIN_MANUAL_MATCHING_ROOM_SUCCESS;
+
+import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingJoinRequest;
 import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingRequest;
 import com.gachtaxi.domain.matching.common.service.ManualMatchingService;
 import com.gachtaxi.global.common.response.ApiResponse;
@@ -31,4 +34,10 @@ public class ManualMatchingController {
         return ApiResponse.response(HttpStatus.OK, CREATE_MANUAL_MATCHING_ROOM_SUCCESS.getMessage(), roomId);
     }
 
+    @Operation(summary = "수동 매칭방 참여")
+    @PostMapping("/join")
+    public ApiResponse<Void> joinManualMatchingRoom(@Valid @RequestBody ManualMatchingJoinRequest request) {
+        manualMatchingService.joinManualMatchingRoom(request.userId(), request.roomId());
+        return ApiResponse.response(HttpStatus.OK, JOIN_MANUAL_MATCHING_ROOM_SUCCESS.getMessage());
+    }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
@@ -8,6 +8,7 @@ import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.LEA
 
 import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingJoinRequest;
 import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingRequest;
+import com.gachtaxi.domain.matching.common.dto.response.MatchingRoomListResponse;
 import com.gachtaxi.domain.matching.common.dto.response.MatchingRoomResponse;
 import com.gachtaxi.domain.matching.common.service.ManualMatchingService;
 import com.gachtaxi.global.auth.jwt.annotation.CurrentMemberId;
@@ -15,8 +16,8 @@ import com.gachtaxi.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -57,15 +58,15 @@ public class ManualMatchingController {
 
     @Operation(summary = "수동 매칭방 조회")
     @GetMapping("/list")
-    public ApiResponse<List<MatchingRoomResponse>> getManualMatchingList() {
-        List<MatchingRoomResponse> rooms = manualMatchingService.getManualMatchingList();
-        return ApiResponse.response(HttpStatus.OK, GET_MANUAL_MATCHING_LIST_SUCCESS.getMessage(), rooms);
+    public ApiResponse<MatchingRoomListResponse> getManualMatchingList(int pageNumber, int pageSize) {
+        Page<MatchingRoomResponse> rooms = manualMatchingService.getManualMatchingList(pageNumber, pageSize);
+        return ApiResponse.response(HttpStatus.OK, GET_MANUAL_MATCHING_LIST_SUCCESS.getMessage(), MatchingRoomListResponse.of(rooms));
     }
 
     @Operation(summary = "나의 매칭(수동) 조회")
     @GetMapping("/my-list")
-    public ApiResponse<List<MatchingRoomResponse>> getMyMatchingList(@CurrentMemberId Long userId) {
-        List<MatchingRoomResponse> rooms = manualMatchingService.getMyMatchingList(userId);
-        return ApiResponse.response(HttpStatus.OK, GET_MY_MATCHING_LIST_SUCCESS.getMessage(), rooms);
+    public ApiResponse<MatchingRoomListResponse> getMyMatchingList(@CurrentMemberId Long userId, int pageNumber, int pageSize) {
+        Page<MatchingRoomResponse> rooms = manualMatchingService.getMyMatchingList(userId, pageNumber, pageSize);
+        return ApiResponse.response(HttpStatus.OK, GET_MY_MATCHING_LIST_SUCCESS.getMessage(), MatchingRoomListResponse.of(rooms));
     }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
@@ -13,7 +13,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,7 +22,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "MANUAL", description = "수동매칭 API")
-@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/matching/manual")

--- a/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
@@ -1,19 +1,24 @@
 package com.gachtaxi.domain.matching.common.controller;
 
 import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.CREATE_MANUAL_MATCHING_ROOM_SUCCESS;
+import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.GET_MANUAL_MATCHING_LIST_SUCCESS;
+import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.GET_MY_MATCHING_LIST_SUCCESS;
 import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.JOIN_MANUAL_MATCHING_ROOM_SUCCESS;
 import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.LEAVE_MANUAL_MATCHING_ROOM_SUCCESS;
 
 import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingJoinRequest;
 import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingRequest;
+import com.gachtaxi.domain.matching.common.dto.response.MatchingRoomResponse;
 import com.gachtaxi.domain.matching.common.service.ManualMatchingService;
 import com.gachtaxi.global.auth.jwt.annotation.CurrentMemberId;
 import com.gachtaxi.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -48,5 +53,19 @@ public class ManualMatchingController {
     public ApiResponse<Void> leaveManualMatchingRoom(@CurrentMemberId Long userId, @PathVariable Long roomId) {
         manualMatchingService.leaveManualMatchingRoom(userId, roomId);
         return ApiResponse.response(HttpStatus.OK, LEAVE_MANUAL_MATCHING_ROOM_SUCCESS.getMessage());
+    }
+
+    @Operation(summary = "수동 매칭방 조회")
+    @GetMapping("/list")
+    public ApiResponse<List<MatchingRoomResponse>> getManualMatchingList() {
+        List<MatchingRoomResponse> rooms = manualMatchingService.getManualMatchingList();
+        return ApiResponse.response(HttpStatus.OK, GET_MANUAL_MATCHING_LIST_SUCCESS.getMessage(), rooms);
+    }
+
+    @Operation(summary = "나의 매칭(수동) 조회")
+    @GetMapping("/my-list")
+    public ApiResponse<List<MatchingRoomResponse>> getMyMatchingList(@CurrentMemberId Long userId) {
+        List<MatchingRoomResponse> rooms = manualMatchingService.getMyMatchingList(userId);
+        return ApiResponse.response(HttpStatus.OK, GET_MY_MATCHING_LIST_SUCCESS.getMessage(), rooms);
     }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
@@ -31,8 +31,8 @@ public class ManualMatchingController {
 
     @Operation(summary = "수동 매칭방 생성")
     @PostMapping("/creation")
-    public ApiResponse<Long> createManualMatchingRoom(@Valid @RequestBody ManualMatchingRequest request) {
-        Long roomId = manualMatchingService.createManualMatchingRoom(request);
+    public ApiResponse<Long> createManualMatchingRoom(@CurrentMemberId Long userId, @Valid @RequestBody ManualMatchingRequest request) {
+        Long roomId = manualMatchingService.createManualMatchingRoom(userId, request);
         return ApiResponse.response(HttpStatus.OK, CREATE_MANUAL_MATCHING_ROOM_SUCCESS.getMessage(), roomId);
     }
 

--- a/src/main/java/com/gachtaxi/domain/matching/common/controller/ResponseMessage.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/controller/ResponseMessage.java
@@ -13,7 +13,14 @@ public enum ResponseMessage {
   // auto matching
   AUTO_MATCHING_REQUEST_ACCEPTED("자동 매칭 요청 전송에 성공했습니다."),
   NOT_SUBSCRIBED_SSE("SSE 구독 후 자동 매칭을 요청할 수 있습니다."),
-  AUTO_MATCHING_REQUEST_CANCELLED("자동 매칭 취소 요청 전송에 성공했습니다.");
+  AUTO_MATCHING_REQUEST_CANCELLED("자동 매칭 취소 요청 전송에 성공했습니다."),
+
+  // manual matching
+  CREATE_MANUAL_MATCHING_ROOM_SUCCESS("수동 매칭방 생성에 성공했습니다."),
+  JOIN_MANUAL_MATCHING_ROOM_SUCCESS("수동 매칭방 참여에 성공했습니다."),
+  LEAVE_MANUAL_MATCHING_ROOM_SUCCESS("매칭방 퇴장이 완료되었습니다."),
+  CONVERT_TO_AUTO_MATCHING_SUCCESS("자동 매칭으로 전환되었습니다.");
+
 
   private final String message;
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/controller/ResponseMessage.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/controller/ResponseMessage.java
@@ -19,8 +19,9 @@ public enum ResponseMessage {
   CREATE_MANUAL_MATCHING_ROOM_SUCCESS("수동 매칭방 생성에 성공했습니다."),
   JOIN_MANUAL_MATCHING_ROOM_SUCCESS("수동 매칭방 참여에 성공했습니다."),
   LEAVE_MANUAL_MATCHING_ROOM_SUCCESS("매칭방 퇴장이 완료되었습니다."),
-  CONVERT_TO_AUTO_MATCHING_SUCCESS("자동 매칭으로 전환되었습니다.");
-
+  CONVERT_TO_AUTO_MATCHING_SUCCESS("자동 매칭으로 전환되었습니다."),
+  GET_MANUAL_MATCHING_LIST_SUCCESS("수동 매칭방 조회에 성공했습니다."),
+  GET_MY_MATCHING_LIST_SUCCESS("내 매칭방 조회에 성공했습니다.");
 
   private final String message;
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingJoinRequest.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingJoinRequest.java
@@ -1,0 +1,11 @@
+package com.gachtaxi.domain.matching.common.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ManualMatchingJoinRequest(
+        @NotNull
+        Long userId,
+        @NotNull
+        Long roomId
+) {
+}

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingJoinRequest.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingJoinRequest.java
@@ -4,8 +4,6 @@ import jakarta.validation.constraints.NotNull;
 
 public record ManualMatchingJoinRequest(
         @NotNull
-        Long userId,
-        @NotNull
         Long roomId
 ) {
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingLeaveRequest.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingLeaveRequest.java
@@ -1,0 +1,9 @@
+package com.gachtaxi.domain.matching.common.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ManualMatchingLeaveRequest(
+        @NotNull Long userId,
+        @NotNull Long roomId
+) {
+}

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingLeaveRequest.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingLeaveRequest.java
@@ -1,9 +1,0 @@
-package com.gachtaxi.domain.matching.common.dto.request;
-
-import jakarta.validation.constraints.NotNull;
-
-public record ManualMatchingLeaveRequest(
-        @NotNull Long userId,
-        @NotNull Long roomId
-) {
-}

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingRequest.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingRequest.java
@@ -9,9 +9,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public record ManualMatchingRequest(
-        @NotNull
-        Long userId,
-
         @NotBlank
         String title,
 

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingRequest.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingRequest.java
@@ -1,0 +1,41 @@
+package com.gachtaxi.domain.matching.common.dto.request;
+
+import com.gachtaxi.domain.matching.common.entity.enums.Tags;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ManualMatchingRequest(
+        @NotNull
+        Long userId,
+
+        @NotBlank
+        String title,
+
+        String description,
+
+        @NotBlank
+        String departure,
+
+        @NotBlank
+        String destination,
+
+        @NotNull
+        LocalDateTime departureTime,
+
+        @Schema(description = "예상 요금")
+        @Min(value = 0)
+        int totalCharge,
+
+        @Schema(description = "매칭 태그")
+        List<String> criteria
+) {
+    public List<Tags> getCriteria() {
+        return this.criteria.stream()
+                .map(Tags::valueOf)
+                .toList();
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingPageableResponse.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingPageableResponse.java
@@ -1,0 +1,22 @@
+package com.gachtaxi.domain.matching.common.dto.response;
+
+import lombok.Builder;
+import org.springframework.data.domain.Page;
+
+
+@Builder
+public record MatchingPageableResponse(
+        int pageNumber,
+        int pageSize,
+        int numberOfElements,
+        boolean last
+) {
+    public static MatchingPageableResponse of(Page<?> page) {
+        return MatchingPageableResponse.builder()
+                .pageNumber(page.getNumber())
+                .pageSize(page.getSize())
+                .numberOfElements(page.getNumberOfElements())
+                .last(page.isLast())
+                .build();
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingRoomListResponse.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingRoomListResponse.java
@@ -1,0 +1,18 @@
+package com.gachtaxi.domain.matching.common.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import org.springframework.data.domain.Page;
+
+@Builder
+public record MatchingRoomListResponse(
+        List<MatchingRoomResponse> rooms,
+        MatchingPageableResponse pageable
+) {
+    public static MatchingRoomListResponse of(Page<MatchingRoomResponse> page) {
+        return MatchingRoomListResponse.builder()
+                .rooms(page.getContent())
+                .pageable(MatchingPageableResponse.of(page))
+                .build();
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingRoomResponse.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingRoomResponse.java
@@ -1,0 +1,29 @@
+package com.gachtaxi.domain.matching.common.dto.response;
+
+import com.gachtaxi.domain.matching.common.entity.MatchingRoom;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record MatchingRoomResponse(
+        Long roomId,
+        String title,
+        String departure,
+        String destination,
+        LocalDateTime departureTime,
+        int maxCapacity,
+        int currentMembers,
+        List<String> tags
+) {
+    public static MatchingRoomResponse from(MatchingRoom matchingRoom) {
+        return new MatchingRoomResponse(
+                matchingRoom.getId(),
+                matchingRoom.getTitle(),
+                matchingRoom.getDeparture(),
+                matchingRoom.getDestination(),
+                matchingRoom.getDepartureTime(),
+                matchingRoom.getCapacity(),
+                matchingRoom.getCurrentMemberCount(),
+                matchingRoom.getTags()
+        );
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
@@ -49,6 +49,7 @@ public class MatchingRoom extends BaseEntity {
   private Members roomMaster;
 
   @Column(name = "title", nullable = false)
+  @Getter
   private String title;
 
   @Column(name = "description", nullable = false)
@@ -64,6 +65,14 @@ public class MatchingRoom extends BaseEntity {
   @Column(name = "departure_time")
   @Getter
   private LocalDateTime departureTime;
+
+  @Column(name = "departure")
+  @Getter
+  private String departure;
+
+  @Column(name = "destination")
+  @Getter
+  private String destination;
 
   @Enumerated(EnumType.STRING)
   private MatchingRoomStatus matchingRoomStatus;
@@ -131,5 +140,16 @@ public class MatchingRoom extends BaseEntity {
             .roomId(this.getId())
             .maxCapacity(this.getCapacity())
             .build();
+  }
+  public int getCurrentMemberCount() {
+    return (int) memberMatchingRoomChargingInfo.stream()
+            .filter(info -> !info.isAlreadyLeft())
+            .count();
+  }
+
+  public List<String> getTags() {
+    return this.matchingRoomTagInfo.stream()
+            .map(tagInfo -> tagInfo.getTags().name())
+            .toList();
   }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
@@ -116,13 +116,14 @@ public class MatchingRoom extends BaseEntity {
         .build();
   }
 
-  public static MatchingRoom manualOf(Members roomMaster, Route route, String title, String description, int maxCapacity, int totalCharge, LocalDateTime departureTime) {
+  public static MatchingRoom manualOf(Members roomMaster, String departure, String destination, String title, String description, int maxCapacity, int totalCharge, LocalDateTime departureTime) {
     return MatchingRoom.builder()
             .capacity(4)
             .roomMaster(roomMaster)
             .title(title)
             .description(description)
-            .route(route)
+            .departure(departure)
+            .destination(destination)
             .totalCharge(totalCharge)
             .departureTime(departureTime)
             .matchingRoomType(MatchingRoomType.MANUAL)

--- a/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
@@ -116,12 +116,13 @@ public class MatchingRoom extends BaseEntity {
         .build();
   }
 
-  public static MatchingRoom manualOf(Members roomMaster, String title, String description, int maxCapacity, int totalCharge, LocalDateTime departureTime) {
+  public static MatchingRoom manualOf(Members roomMaster, Route route, String title, String description, int maxCapacity, int totalCharge, LocalDateTime departureTime) {
     return MatchingRoom.builder()
             .capacity(4)
             .roomMaster(roomMaster)
             .title(title)
             .description(description)
+            .route(route)
             .totalCharge(totalCharge)
             .departureTime(departureTime)
             .matchingRoomType(MatchingRoomType.MANUAL)

--- a/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
@@ -120,10 +120,12 @@ public class MatchingRoom extends BaseEntity {
             .matchingRoomStatus(MatchingRoomStatus.ACTIVE)
             .build();
   }
+
   public boolean containsTag(Tags tag) {
     return this.matchingRoomTagInfo.stream()
             .anyMatch(tagInfo -> tagInfo.matchesTag(tag));
   }
+
   public FindRoomResult toFindRoomResult() {
     return FindRoomResult.builder()
             .roomId(this.getId())

--- a/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
@@ -116,13 +116,12 @@ public class MatchingRoom extends BaseEntity {
         .build();
   }
 
-  public static MatchingRoom manualOf(Members roomMaster, Route route, String title, String description, int maxCapacity, int totalCharge, LocalDateTime departureTime) {
+  public static MatchingRoom manualOf(Members roomMaster, String title, String description, int maxCapacity, int totalCharge, LocalDateTime departureTime) {
     return MatchingRoom.builder()
             .capacity(4)
             .roomMaster(roomMaster)
             .title(title)
             .description(description)
-            .route(route)
             .totalCharge(totalCharge)
             .departureTime(departureTime)
             .matchingRoomType(MatchingRoomType.MANUAL)

--- a/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoomTagInfo.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoomTagInfo.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
@@ -23,6 +24,7 @@ public class MatchingRoomTagInfo extends BaseEntity {
   private MatchingRoom matchingRoom;
 
   @Enumerated(EnumType.STRING)
+  @Getter
   private Tags tags;
 
   public static MatchingRoomTagInfo of(MatchingRoom matchingRoom, Tags tag) {

--- a/src/main/java/com/gachtaxi/domain/matching/common/entity/Route.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/entity/Route.java
@@ -22,11 +22,4 @@ public class Route extends BaseEntity {
   private double endLongitude;
   private double endLatitude;
   private String endLocationName;
-
-  public static Route of(String startLocation, String endLocation) {
-    return Route.builder()
-            .startLocationName(startLocation)
-            .endLocationName(endLocation)
-            .build();
-  }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/entity/Route.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/entity/Route.java
@@ -1,6 +1,5 @@
 package com.gachtaxi.domain.matching.common.entity;
 
-import com.gachtaxi.domain.matching.event.dto.kafka_topic.MatchRoomCreatedEvent;
 import com.gachtaxi.global.common.entity.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
@@ -23,4 +22,11 @@ public class Route extends BaseEntity {
   private double endLongitude;
   private double endLatitude;
   private String endLocationName;
+
+  public static Route of(String startLocation, String endLocation) {
+    return Route.builder()
+            .startLocationName(startLocation)
+            .endLocationName(endLocation)
+            .build();
+  }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/entity/enums/MatchingRoomType.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/entity/enums/MatchingRoomType.java
@@ -1,0 +1,5 @@
+package com.gachtaxi.domain.matching.common.entity.enums;
+
+public enum MatchingRoomType {
+    AUTO, MANUAL
+}

--- a/src/main/java/com/gachtaxi/domain/matching/common/exception/ErrorMessage.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/exception/ErrorMessage.java
@@ -16,7 +16,8 @@ public enum ErrorMessage {
   NOT_DEFINED_KAFKA_TEMPLATE("해당 이벤트와 맞는 KafkaTemplate이 정의되지 않았습니다."),
   DUPLICATED_MATCHING_ROOM("이미 존재하는 매칭 방입니다."),
   NOT_FOUND_PAGE("페이지 번호는 0 이상이어야 합니다."),
-  ALREADY_IN_MATCHING_ROOM("이미 매칭 방에 참가한 멤버입니다.");
+  ALREADY_IN_MATCHING_ROOM("이미 매칭 방에 참가한 멤버입니다."),
+  MATCHING_ROOM_NOT_JOIN_OWN("자신이 만든 매칭 방에는 참가할 수 없습니다.");
 
   private final String message;
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/exception/ErrorMessage.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/exception/ErrorMessage.java
@@ -17,7 +17,8 @@ public enum ErrorMessage {
   DUPLICATED_MATCHING_ROOM("이미 존재하는 매칭 방입니다."),
   NOT_FOUND_PAGE("페이지 번호는 0 이상이어야 합니다."),
   ALREADY_IN_MATCHING_ROOM("이미 매칭 방에 참가한 멤버입니다."),
-  MATCHING_ROOM_NOT_JOIN_OWN("자신이 만든 매칭 방에는 참가할 수 없습니다.");
+  MATCHING_ROOM_NOT_JOIN_OWN("자신이 만든 매칭 방에는 참가할 수 없습니다."),
+  NOT_EQUAL_START_DESTINATION("출발지와 도착지는 같을 수 없습니다.");
 
   private final String message;
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/exception/MatchingRoomNotJoinOwnException.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/exception/MatchingRoomNotJoinOwnException.java
@@ -1,0 +1,12 @@
+package com.gachtaxi.domain.matching.common.exception;
+
+import static com.gachtaxi.domain.matching.common.exception.ErrorMessage.MATCHING_ROOM_NOT_JOIN_OWN;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import com.gachtaxi.global.common.exception.BaseException;
+
+public class MatchingRoomNotJoinOwnException extends BaseException {
+    public MatchingRoomNotJoinOwnException() {
+        super(BAD_REQUEST, MATCHING_ROOM_NOT_JOIN_OWN.getMessage());
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/matching/common/exception/NotEqualStartAndDestinationException.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/exception/NotEqualStartAndDestinationException.java
@@ -1,0 +1,12 @@
+package com.gachtaxi.domain.matching.common.exception;
+
+import static com.gachtaxi.domain.matching.common.exception.ErrorMessage.NOT_EQUAL_START_DESTINATION;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import com.gachtaxi.global.common.exception.BaseException;
+
+public class NotEqualStartAndDestinationException extends BaseException {
+    public NotEqualStartAndDestinationException() {
+        super(BAD_REQUEST, NOT_EQUAL_START_DESTINATION.getMessage());
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/matching/common/exception/RoomMasterCantJoinException.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/exception/RoomMasterCantJoinException.java
@@ -5,8 +5,8 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 import com.gachtaxi.global.common.exception.BaseException;
 
-public class MatchingRoomNotJoinOwnException extends BaseException {
-    public MatchingRoomNotJoinOwnException() {
+public class RoomMasterCantJoinException extends BaseException {
+    public RoomMasterCantJoinException() {
         super(BAD_REQUEST, MATCHING_ROOM_NOT_JOIN_OWN.getMessage());
     }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/repository/MatchingRoomRepository.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/repository/MatchingRoomRepository.java
@@ -36,6 +36,4 @@ public interface MatchingRoomRepository extends JpaRepository<MatchingRoom, Long
 
     @Query("SELECT m.matchingRoom FROM MemberMatchingRoomChargingInfo m WHERE m.members = :user ORDER BY m.matchingRoom.id DESC")
     Page<MatchingRoom> findByMemberInMatchingRoom(@Param("user") Members user, Pageable pageable);
-
-    List<MatchingRoom> findByDepartureAndDestination(String departure, String destination);
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/repository/MatchingRoomRepository.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/repository/MatchingRoomRepository.java
@@ -5,7 +5,6 @@ import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomStatus;
 import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomType;
 import com.gachtaxi.domain.members.entity.Members;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -38,5 +37,5 @@ public interface MatchingRoomRepository extends JpaRepository<MatchingRoom, Long
     @Query("SELECT m.matchingRoom FROM MemberMatchingRoomChargingInfo m WHERE m.members = :user ORDER BY m.matchingRoom.id DESC")
     Page<MatchingRoom> findByMemberInMatchingRoom(@Param("user") Members user, Pageable pageable);
 
-    Optional<MatchingRoom> findByDepartureAndDestination(String departure, String destination);
+    List<MatchingRoom> findByDepartureAndDestination(String departure, String destination);
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/repository/MatchingRoomRepository.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/repository/MatchingRoomRepository.java
@@ -5,6 +5,8 @@ import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomStatus;
 import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomType;
 import com.gachtaxi.domain.members.entity.Members;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -30,8 +32,8 @@ public interface MatchingRoomRepository extends JpaRepository<MatchingRoom, Long
             "AND m.paymentStatus != 'LEFT'")
     boolean existsByMemberInMatchingRoom(@Param("user") Members user);
 
-    List<MatchingRoom> findByMatchingRoomTypeAndMatchingRoomStatus(MatchingRoomType type, MatchingRoomStatus status);
+    Page<MatchingRoom> findByMatchingRoomTypeAndMatchingRoomStatus(MatchingRoomType type, MatchingRoomStatus status, Pageable pageable);
 
-    @Query("SELECT m.matchingRoom FROM MemberMatchingRoomChargingInfo m WHERE m.members = :user")
-    List<MatchingRoom> findByMemberInMatchingRoom(@Param("user") Members user);
+    @Query("SELECT m.matchingRoom FROM MemberMatchingRoomChargingInfo m WHERE m.members = :user ORDER BY m.matchingRoom.id DESC")
+    Page<MatchingRoom> findByMemberInMatchingRoom(@Param("user") Members user, Pageable pageable);
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/repository/MatchingRoomRepository.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/repository/MatchingRoomRepository.java
@@ -5,6 +5,7 @@ import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomStatus;
 import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomType;
 import com.gachtaxi.domain.members.entity.Members;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -36,4 +37,6 @@ public interface MatchingRoomRepository extends JpaRepository<MatchingRoom, Long
 
     @Query("SELECT m.matchingRoom FROM MemberMatchingRoomChargingInfo m WHERE m.members = :user ORDER BY m.matchingRoom.id DESC")
     Page<MatchingRoom> findByMemberInMatchingRoom(@Param("user") Members user, Pageable pageable);
+
+    Optional<MatchingRoom> findByDepartureAndDestination(String departure, String destination);
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/repository/MatchingRoomRepository.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/repository/MatchingRoomRepository.java
@@ -1,6 +1,8 @@
 package com.gachtaxi.domain.matching.common.repository;
 
 import com.gachtaxi.domain.matching.common.entity.MatchingRoom;
+import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomStatus;
+import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomType;
 import com.gachtaxi.domain.members.entity.Members;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -27,4 +29,9 @@ public interface MatchingRoomRepository extends JpaRepository<MatchingRoom, Long
             "AND r.matchingRoomStatus = 'ACTIVE' "+
             "AND m.paymentStatus != 'LEFT'")
     boolean existsByMemberInMatchingRoom(@Param("user") Members user);
+
+    List<MatchingRoom> findByMatchingRoomTypeAndMatchingRoomStatus(MatchingRoomType type, MatchingRoomStatus status);
+
+    @Query("SELECT m.matchingRoom FROM MemberMatchingRoomChargingInfo m WHERE m.members = :user")
+    List<MatchingRoom> findByMemberInMatchingRoom(@Param("user") Members user);
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/repository/MemberMatchingRoomChargingInfoRepository.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/repository/MemberMatchingRoomChargingInfoRepository.java
@@ -14,4 +14,6 @@ public interface MemberMatchingRoomChargingInfoRepository extends JpaRepository<
 
   List<MemberMatchingRoomChargingInfo> findByMatchingRoomAndPaymentStatus(MatchingRoom matchingRoom, PaymentStatus paymentStatus);
   Optional<MemberMatchingRoomChargingInfo> findByMembersAndMatchingRoom(Members members, MatchingRoom matchingRoom);
+
+  int countByMatchingRoomAndPaymentStatus(MatchingRoom matchingRoom, PaymentStatus paymentStatus);
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/repository/MemberMatchingRoomChargingInfoRepository.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/repository/MemberMatchingRoomChargingInfoRepository.java
@@ -16,4 +16,6 @@ public interface MemberMatchingRoomChargingInfoRepository extends JpaRepository<
   Optional<MemberMatchingRoomChargingInfo> findByMembersAndMatchingRoom(Members members, MatchingRoom matchingRoom);
 
   int countByMatchingRoomAndPaymentStatus(MatchingRoom matchingRoom, PaymentStatus paymentStatus);
+
+  boolean existsByMembersAndMatchingRoom(Members members, MatchingRoom matchingRoom);
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/repository/RouteRepository.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/repository/RouteRepository.java
@@ -1,11 +1,9 @@
 package com.gachtaxi.domain.matching.common.repository;
 
 import com.gachtaxi.domain.matching.common.entity.Route;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RouteRepository extends JpaRepository<Route, Long> {
-    Optional<Route> findByStartLocationNameAndEndLocationName(String departure, String destination);
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/repository/RouteRepository.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/repository/RouteRepository.java
@@ -1,11 +1,9 @@
 package com.gachtaxi.domain.matching.common.repository;
 
 import com.gachtaxi.domain.matching.common.entity.Route;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RouteRepository extends JpaRepository<Route, Long> {
-    List<Route> findByStartLocationNameAndEndLocationName(String departure, String destination);
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/repository/RouteRepository.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/repository/RouteRepository.java
@@ -7,5 +7,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RouteRepository extends JpaRepository<Route, Long> {
-    Optional<Route> findByStartLocationNameAndEndLocationName(String startLocation, String endLocation);
+    Optional<Route> findByStartLocationNameAndEndLocationName(String departure, String destination);
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/repository/RouteRepository.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/repository/RouteRepository.java
@@ -1,9 +1,11 @@
 package com.gachtaxi.domain.matching.common.repository;
 
 import com.gachtaxi.domain.matching.common.entity.Route;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RouteRepository extends JpaRepository<Route, Long> {
+    List<Route> findByStartLocationNameAndEndLocationName(String departure, String destination);
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/repository/RouteRepository.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/repository/RouteRepository.java
@@ -1,10 +1,11 @@
 package com.gachtaxi.domain.matching.common.repository;
 
 import com.gachtaxi.domain.matching.common.entity.Route;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RouteRepository extends JpaRepository<Route, Long> {
-
+    Optional<Route> findByStartLocationNameAndEndLocationName(String startLocation, String endLocation);
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -5,6 +5,7 @@ import com.gachtaxi.domain.matching.common.entity.MatchingRoom;
 import com.gachtaxi.domain.matching.common.entity.MemberMatchingRoomChargingInfo;
 import com.gachtaxi.domain.matching.common.entity.Route;
 import com.gachtaxi.domain.matching.common.entity.enums.PaymentStatus;
+import com.gachtaxi.domain.matching.common.exception.AlreadyInMatchingRoomException;
 import com.gachtaxi.domain.matching.common.exception.MemberAlreadyLeftMatchingRoomException;
 import com.gachtaxi.domain.matching.common.exception.MemberNotInMatchingRoomException;
 import com.gachtaxi.domain.matching.common.exception.NoSuchMatchingRoomException;
@@ -35,6 +36,10 @@ public class ManualMatchingService {
     */
     public Long createManualMatchingRoom(ManualMatchingRequest request) {
         Members roomMaster = memberService.findById(request.userId());
+
+        if (matchingRoomRepository.existsByMemberInMatchingRoom(roomMaster)) {
+            throw new AlreadyInMatchingRoomException();
+        }
 
         Route route = matchingRoomService.saveRoute(request.departure(), request.destination());
 

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -68,7 +68,7 @@ public class ManualMatchingService {
                 request.departureTime()
         );
 
-        MatchingRoom savedMatchingRoom = matchingRoomService.saveRoute(matchingRoom);
+        MatchingRoom savedMatchingRoom = matchingRoomRepository.save(matchingRoom);
 
         matchingRoomService.saveMatchingRoomTagInfoForManual(savedMatchingRoom, request.getCriteria());
         matchingRoomService.saveRoomMasterChargingInfoForManual(savedMatchingRoom, roomMaster);

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -13,7 +13,6 @@ import com.gachtaxi.domain.matching.common.exception.MemberNotInMatchingRoomExce
 import com.gachtaxi.domain.matching.common.exception.NoSuchMatchingRoomException;
 import com.gachtaxi.domain.matching.common.exception.NotActiveMatchingRoomException;
 import com.gachtaxi.domain.matching.common.repository.MatchingRoomRepository;
-import com.gachtaxi.domain.matching.common.repository.MatchingRoomTagInfoRepository;
 import com.gachtaxi.domain.matching.common.repository.MemberMatchingRoomChargingInfoRepository;
 import com.gachtaxi.domain.members.entity.Members;
 import com.gachtaxi.domain.members.service.MemberService;
@@ -33,7 +32,6 @@ public class ManualMatchingService {
     private final MemberService memberService;
     private final MatchingRoomService matchingRoomService;
     private final MatchingRoomRepository matchingRoomRepository;
-    private final MatchingRoomTagInfoRepository matchingRoomTagInfoRepository;
     private final MemberMatchingRoomChargingInfoRepository memberMatchingRoomChargingInfoRepository;
 
     /*

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -4,6 +4,7 @@ import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingRequest;
 import com.gachtaxi.domain.matching.common.dto.response.MatchingRoomResponse;
 import com.gachtaxi.domain.matching.common.entity.MatchingRoom;
 import com.gachtaxi.domain.matching.common.entity.MemberMatchingRoomChargingInfo;
+import com.gachtaxi.domain.matching.common.entity.Route;
 import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomStatus;
 import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomType;
 import com.gachtaxi.domain.matching.common.entity.enums.PaymentStatus;
@@ -57,17 +58,19 @@ public class ManualMatchingService {
             throw new NotEqualStartAndDestinationException();
         }
 
-        MatchingRoom existingRoom = matchingRoomRepository.findByDepartureAndDestination(request.departure(), request.destination())
-                .orElseGet(() -> MatchingRoom.manualOf(
+        Route route = matchingRoomService.saveRoute(request.departure(), request.destination());
+
+        MatchingRoom matchingRoom = MatchingRoom.manualOf(
                 roomMaster,
+                route,
                 request.title(),
                 request.description(),
                 4,
                 request.totalCharge(),
                 request.departureTime()
-        ));
+        );
 
-        MatchingRoom savedMatchingRoom = matchingRoomRepository.save(existingRoom);
+        MatchingRoom savedMatchingRoom = matchingRoomRepository.save(matchingRoom);
 
         matchingRoomService.saveMatchingRoomTagInfoForManual(savedMatchingRoom, request.getCriteria());
         matchingRoomService.saveRoomMasterChargingInfoForManual(savedMatchingRoom, roomMaster);

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -1,9 +1,12 @@
 package com.gachtaxi.domain.matching.common.service;
 
 import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingRequest;
+import com.gachtaxi.domain.matching.common.dto.response.MatchingRoomResponse;
 import com.gachtaxi.domain.matching.common.entity.MatchingRoom;
 import com.gachtaxi.domain.matching.common.entity.MemberMatchingRoomChargingInfo;
 import com.gachtaxi.domain.matching.common.entity.Route;
+import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomStatus;
+import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomType;
 import com.gachtaxi.domain.matching.common.entity.enums.PaymentStatus;
 import com.gachtaxi.domain.matching.common.exception.DuplicatedMatchingRoomException;
 import com.gachtaxi.domain.matching.common.exception.RoomMasterCantJoinException;
@@ -170,6 +173,30 @@ public class ManualMatchingService {
                  this.matchingRoomRepository.save(matchingRoom);
              }
          }
+    }
+    /*
+       수동 매칭 방 리스트 조회
+    */
+    @Transactional
+    public List<MatchingRoomResponse> getManualMatchingList() {
+        List<MatchingRoom> rooms = matchingRoomRepository.findByMatchingRoomTypeAndMatchingRoomStatus(
+                MatchingRoomType.MANUAL, MatchingRoomStatus.ACTIVE);
+
+        return rooms.stream()
+                .map(MatchingRoomResponse::from)
+                .toList();
+    }
+    /*
+       나의 매칭방 리스트 조회
+     */
+    @Transactional
+    public List<MatchingRoomResponse> getMyMatchingList(Long userId) {
+        Members user = memberService.findById(userId);
+        List<MatchingRoom> rooms = matchingRoomRepository.findByMemberInMatchingRoom(user);
+
+        return rooms.stream()
+                .map(MatchingRoomResponse::from)
+                .toList();
     }
 }
 

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -1,0 +1,154 @@
+package com.gachtaxi.domain.matching.common.service;
+
+import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingRequest;
+import com.gachtaxi.domain.matching.common.entity.MatchingRoom;
+import com.gachtaxi.domain.matching.common.entity.MemberMatchingRoomChargingInfo;
+import com.gachtaxi.domain.matching.common.entity.Route;
+import com.gachtaxi.domain.matching.common.entity.enums.PaymentStatus;
+import com.gachtaxi.domain.matching.common.exception.MemberAlreadyLeftMatchingRoomException;
+import com.gachtaxi.domain.matching.common.exception.MemberNotInMatchingRoomException;
+import com.gachtaxi.domain.matching.common.exception.NoSuchMatchingRoomException;
+import com.gachtaxi.domain.matching.common.exception.NotActiveMatchingRoomException;
+import com.gachtaxi.domain.matching.common.repository.MatchingRoomRepository;
+import com.gachtaxi.domain.matching.common.repository.MemberMatchingRoomChargingInfoRepository;
+import com.gachtaxi.domain.members.entity.Members;
+import com.gachtaxi.domain.members.service.MemberService;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ManualMatchingService {
+
+    private final MemberService memberService;
+    private final MatchingRoomService matchingRoomService;
+    private final MatchingRoomRepository matchingRoomRepository;
+    private final MemberMatchingRoomChargingInfoRepository memberMatchingRoomChargingInfoRepository;
+
+    /*
+      수동 매칭 방 생성
+    */
+    public Long createManualMatchingRoom(ManualMatchingRequest request) {
+        Members roomMaster = memberService.findById(request.userId());
+
+        Route route = matchingRoomService.saveRoute(request.departure(), request.destination());
+
+        MatchingRoom matchingRoom = MatchingRoom.manualOf(
+                roomMaster,
+                route,
+                request.title(),
+                request.description(),
+                4,
+                request.totalCharge(),
+                request.departureTime()
+        );
+
+        MatchingRoom savedMatchingRoom = matchingRoomRepository.save(matchingRoom);
+
+        matchingRoomService.saveMatchingRoomTagInfoForManual(savedMatchingRoom, request.getCriteria());
+        matchingRoomService.saveRoomMasterChargingInfoForManual(savedMatchingRoom, roomMaster);
+
+        return savedMatchingRoom.getId();
+    }
+
+    /*
+      수동 매칭방 참여
+     */
+    public void joinManualMatchingRoom(Long userId, Long roomId) {
+        Members user = memberService.findById(userId);
+
+        MatchingRoom matchingRoom = this.matchingRoomRepository.findById(roomId)
+                .orElseThrow(NoSuchMatchingRoomException::new);
+
+        if (!matchingRoom.isActive()) {
+            throw new NotActiveMatchingRoomException();
+        }
+
+        Optional<MemberMatchingRoomChargingInfo> joinedInPast = this.memberMatchingRoomChargingInfoRepository
+                .findByMembersAndMatchingRoom(user, matchingRoom);
+
+        MemberMatchingRoomChargingInfo memberInfo;
+        if (joinedInPast.isPresent()) {
+            memberInfo = joinedInPast.get().joinMatchingRoom();
+        } else {
+            memberInfo = MemberMatchingRoomChargingInfo.notPayedOf(matchingRoom, user);
+        }
+
+        this.memberMatchingRoomChargingInfoRepository.save(memberInfo);
+
+        List<MemberMatchingRoomChargingInfo> existMembers = this.memberMatchingRoomChargingInfoRepository
+                .findByMatchingRoomAndPaymentStatus(matchingRoom, PaymentStatus.NOT_PAYED);
+
+        int distributedCharge = (int) Math.ceil((double) matchingRoom.getTotalCharge() / (existMembers.size() + 1));
+
+        matchingRoomService.updateExistMembersChargeForManual(existMembers, distributedCharge);
+
+        int nowMemberCount = existMembers.size() + 1;
+
+        if (matchingRoom.isFull(nowMemberCount)) {
+            matchingRoom.completeMatchingRoom();
+            this.matchingRoomRepository.save(matchingRoom);
+        }
+    }
+    /*
+      todo 수동 매칭 → 자동 매칭 전환 : 추후 고도화시, 10분전에 유저에게 알림을 주고 자동 매칭으로 전환
+    */
+    public void convertToAutoMatching(Long roomId) {
+        MatchingRoom matchingRoom = this.matchingRoomRepository.findById(roomId)
+                .orElseThrow(NoSuchMatchingRoomException::new);
+
+        if (!matchingRoom.isActive()) {
+            throw new NotActiveMatchingRoomException();
+        }
+
+        if (LocalDateTime.now().isAfter(matchingRoom.getDepartureTime().minusMinutes(10))) {
+
+            int currentMembers = this.memberMatchingRoomChargingInfoRepository
+                    .countByMatchingRoomAndPaymentStatus(matchingRoom, PaymentStatus.NOT_PAYED);
+
+            if (matchingRoom.isAutoConvertible(currentMembers)) {
+                matchingRoom.convertToAutoMatching();
+                matchingRoomRepository.save(matchingRoom);
+            }
+        }
+    }
+
+    /*
+      방장 취소 + 방 삭제
+    */
+    public void leaveManualMatchingRoom(Long userId, Long roomId) {
+        Members user = this.memberService.findById(userId);
+         MatchingRoom matchingRoom = this.matchingRoomRepository.findById(roomId)
+                 .orElseThrow(NoSuchMatchingRoomException::new);
+
+         MemberMatchingRoomChargingInfo memberMatchingRoomChargingInfo =
+                 this.memberMatchingRoomChargingInfoRepository.findByMembersAndMatchingRoom(user, matchingRoom)
+                         .orElseThrow(MemberNotInMatchingRoomException::new);
+
+         if (memberMatchingRoomChargingInfo.isAlreadyLeft()) {
+              throw new MemberAlreadyLeftMatchingRoomException();
+         }
+
+         memberMatchingRoomChargingInfo.leftMatchingRoom();
+         this.memberMatchingRoomChargingInfoRepository.save(memberMatchingRoomChargingInfo);
+
+         if (user.isRoomMaster(matchingRoom)) {
+             List<MemberMatchingRoomChargingInfo> remainingMembers =
+                     this.memberMatchingRoomChargingInfoRepository.findByMatchingRoomAndPaymentStatus(matchingRoom, PaymentStatus.NOT_PAYED);
+
+             if (remainingMembers.isEmpty()) {
+                 this.matchingRoomRepository.delete(matchingRoom);
+             } else {
+                 Members newRoomMaster = remainingMembers.get(0).getMembers();
+                 matchingRoom.changeRoomMaster(newRoomMaster);
+                 this.matchingRoomRepository.save(matchingRoom);
+             }
+         }
+    }
+}
+

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -5,7 +5,7 @@ import com.gachtaxi.domain.matching.common.entity.MatchingRoom;
 import com.gachtaxi.domain.matching.common.entity.MemberMatchingRoomChargingInfo;
 import com.gachtaxi.domain.matching.common.entity.Route;
 import com.gachtaxi.domain.matching.common.entity.enums.PaymentStatus;
-import com.gachtaxi.domain.matching.common.exception.AlreadyInMatchingRoomException;
+import com.gachtaxi.domain.matching.common.exception.DuplicatedMatchingRoomException;
 import com.gachtaxi.domain.matching.common.exception.MemberAlreadyLeftMatchingRoomException;
 import com.gachtaxi.domain.matching.common.exception.MemberNotInMatchingRoomException;
 import com.gachtaxi.domain.matching.common.exception.NoSuchMatchingRoomException;
@@ -38,7 +38,7 @@ public class ManualMatchingService {
         Members roomMaster = memberService.findById(request.userId());
 
         if (matchingRoomRepository.existsByMemberInMatchingRoom(roomMaster)) {
-            throw new AlreadyInMatchingRoomException();
+            throw new DuplicatedMatchingRoomException();
         }
 
         Route route = matchingRoomService.saveRoute(request.departure(), request.destination());

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -6,7 +6,7 @@ import com.gachtaxi.domain.matching.common.entity.MemberMatchingRoomChargingInfo
 import com.gachtaxi.domain.matching.common.entity.Route;
 import com.gachtaxi.domain.matching.common.entity.enums.PaymentStatus;
 import com.gachtaxi.domain.matching.common.exception.DuplicatedMatchingRoomException;
-import com.gachtaxi.domain.matching.common.exception.MatchingRoomNotJoinOwnException;
+import com.gachtaxi.domain.matching.common.exception.RoomMasterCantJoinException;
 import com.gachtaxi.domain.matching.common.exception.MemberAlreadyJoinedException;
 import com.gachtaxi.domain.matching.common.exception.MemberAlreadyLeftMatchingRoomException;
 import com.gachtaxi.domain.matching.common.exception.MemberNotInMatchingRoomException;
@@ -82,7 +82,7 @@ public class ManualMatchingService {
         }
 
         if (matchingRoom.getRoomMaster().equals(user)) {
-            throw new MatchingRoomNotJoinOwnException();
+            throw new RoomMasterCantJoinException();
         }
 
         if (this.memberMatchingRoomChargingInfoRepository.existsByMembersAndMatchingRoom(user, matchingRoom)) {

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -6,6 +6,8 @@ import com.gachtaxi.domain.matching.common.entity.MemberMatchingRoomChargingInfo
 import com.gachtaxi.domain.matching.common.entity.Route;
 import com.gachtaxi.domain.matching.common.entity.enums.PaymentStatus;
 import com.gachtaxi.domain.matching.common.exception.DuplicatedMatchingRoomException;
+import com.gachtaxi.domain.matching.common.exception.MatchingRoomNotJoinOwnException;
+import com.gachtaxi.domain.matching.common.exception.MemberAlreadyJoinedException;
 import com.gachtaxi.domain.matching.common.exception.MemberAlreadyLeftMatchingRoomException;
 import com.gachtaxi.domain.matching.common.exception.MemberNotInMatchingRoomException;
 import com.gachtaxi.domain.matching.common.exception.NoSuchMatchingRoomException;
@@ -72,6 +74,14 @@ public class ManualMatchingService {
 
         if (!matchingRoom.isActive()) {
             throw new NotActiveMatchingRoomException();
+        }
+
+        if (matchingRoom.getRoomMaster().equals(user)) {
+            throw new MatchingRoomNotJoinOwnException();
+        }
+
+        if (this.memberMatchingRoomChargingInfoRepository.existsByMembersAndMatchingRoom(user, matchingRoom)) {
+            throw new MemberAlreadyJoinedException();
         }
 
         Optional<MemberMatchingRoomChargingInfo> joinedInPast = this.memberMatchingRoomChargingInfoRepository

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -4,7 +4,6 @@ import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingRequest;
 import com.gachtaxi.domain.matching.common.dto.response.MatchingRoomResponse;
 import com.gachtaxi.domain.matching.common.entity.MatchingRoom;
 import com.gachtaxi.domain.matching.common.entity.MemberMatchingRoomChargingInfo;
-import com.gachtaxi.domain.matching.common.entity.Route;
 import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomStatus;
 import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomType;
 import com.gachtaxi.domain.matching.common.entity.enums.PaymentStatus;
@@ -58,11 +57,10 @@ public class ManualMatchingService {
             throw new NotEqualStartAndDestinationException();
         }
 
-        Route route = matchingRoomService.saveRoute(request.departure(), request.destination());
-
         MatchingRoom matchingRoom = MatchingRoom.manualOf(
                 roomMaster,
-                route,
+                request.departure(),
+                request.destination(),
                 request.title(),
                 request.description(),
                 4,
@@ -70,7 +68,7 @@ public class ManualMatchingService {
                 request.departureTime()
         );
 
-        MatchingRoom savedMatchingRoom = matchingRoomRepository.save(matchingRoom);
+        MatchingRoom savedMatchingRoom = matchingRoomService.saveRoute(matchingRoom);
 
         matchingRoomService.saveMatchingRoomTagInfoForManual(savedMatchingRoom, request.getCriteria());
         matchingRoomService.saveRoomMasterChargingInfoForManual(savedMatchingRoom, roomMaster);

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -38,8 +38,8 @@ public class ManualMatchingService {
       수동 매칭 방 생성
     */
     @Transactional
-    public Long createManualMatchingRoom(ManualMatchingRequest request) {
-        Members roomMaster = memberService.findById(request.userId());
+    public Long createManualMatchingRoom(Long userId, ManualMatchingRequest request) {
+        Members roomMaster = memberService.findById(userId);
 
         if (matchingRoomRepository.existsByMemberInMatchingRoom(roomMaster)) {
             throw new DuplicatedMatchingRoomException();

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -79,7 +79,7 @@ public class ManualMatchingService {
             throw new NotActiveMatchingRoomException();
         }
 
-        if (matchingRoom.getRoomMaster().equals(user)) {
+        if (user.isRoomMaster(matchingRoom)) {
             throw new RoomMasterCantJoinException();
         }
 

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/MatchingRoomService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/MatchingRoomService.java
@@ -83,20 +83,18 @@ public class MatchingRoomService {
             .build();
     return this.routeRepository.save(route);
   }
-  public Route saveRoute(String departure, String destination) {
+  public MatchingRoom saveRoute(MatchingRoom matchingRoom) {
 
-    List<Route> existingRoutes = routeRepository.findByStartLocationNameAndEndLocationName(departure, destination);
+    String departure = matchingRoom.getDeparture();
+    String destination = matchingRoom.getDestination();
 
-    if (!existingRoutes.isEmpty()) {
-      return existingRoutes.get(0);
+    List<MatchingRoom> existingRooms = matchingRoomRepository.findByDepartureAndDestination(departure, destination);
+
+    if (!existingRooms.isEmpty()) {
+      return existingRooms.get(0);
     }
 
-    Route route = Route.builder()
-            .startLocationName(departure)
-            .endLocationName(destination)
-            .build();
-
-    return this.routeRepository.save(route);
+    return matchingRoomRepository.save(matchingRoom);
   }
   private void saveMatchingRoomTagInfo(MatchingRoom matchingRoom, List<Tags> tags) {
     tags.forEach(tag -> this.matchingRoomTagInfoRepository.save(MatchingRoomTagInfo.of(matchingRoom, tag)));

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/MatchingRoomService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/MatchingRoomService.java
@@ -84,6 +84,13 @@ public class MatchingRoomService {
     return this.routeRepository.save(route);
   }
   public Route saveRoute(String departure, String destination) {
+
+    List<Route> existingRoutes = routeRepository.findByStartLocationNameAndEndLocationName(departure, destination);
+
+    if (!existingRoutes.isEmpty()) {
+      return existingRoutes.get(0);
+    }
+
     Route route = Route.builder()
             .startLocationName(departure)
             .endLocationName(destination)

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/MatchingRoomService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/MatchingRoomService.java
@@ -83,19 +83,7 @@ public class MatchingRoomService {
             .build();
     return this.routeRepository.save(route);
   }
-  public MatchingRoom saveRoute(MatchingRoom matchingRoom) {
 
-    String departure = matchingRoom.getDeparture();
-    String destination = matchingRoom.getDestination();
-
-    List<MatchingRoom> existingRooms = matchingRoomRepository.findByDepartureAndDestination(departure, destination);
-
-    if (!existingRooms.isEmpty()) {
-      return existingRooms.get(0);
-    }
-
-    return matchingRoomRepository.save(matchingRoom);
-  }
   private void saveMatchingRoomTagInfo(MatchingRoom matchingRoom, List<Tags> tags) {
     tags.forEach(tag -> this.matchingRoomTagInfoRepository.save(MatchingRoomTagInfo.of(matchingRoom, tag)));
   }

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/MatchingRoomService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/MatchingRoomService.java
@@ -83,15 +83,26 @@ public class MatchingRoomService {
             .build();
     return this.routeRepository.save(route);
   }
+  public Route saveRoute(String departure, String destination) {
+    Route route = Route.builder()
+            .startLocationName(departure)
+            .endLocationName(destination)
+            .build();
 
+    return this.routeRepository.save(route);
+  }
   private void saveMatchingRoomTagInfo(MatchingRoom matchingRoom, List<Tags> tags) {
     tags.forEach(tag -> this.matchingRoomTagInfoRepository.save(MatchingRoomTagInfo.of(matchingRoom, tag)));
   }
-
+  public void saveMatchingRoomTagInfoForManual(MatchingRoom matchingRoom, List<Tags> tags) {
+    tags.forEach(tag -> this.matchingRoomTagInfoRepository.save(MatchingRoomTagInfo.of(matchingRoom, tag)));
+  }
   private void saveRoomMasterChargingInfo(MatchingRoom matchingRoom, Members members) {
     this.memberMatchingRoomChargingInfoRepository.save(MemberMatchingRoomChargingInfo.notPayedOf(matchingRoom, members));
   }
-
+  public void saveRoomMasterChargingInfoForManual(MatchingRoom matchingRoom, Members members) {
+    this.memberMatchingRoomChargingInfoRepository.save(MemberMatchingRoomChargingInfo.notPayedOf(matchingRoom, members));
+  }
   public void joinMemberToMatchingRoom(MatchMemberJoinedEvent matchMemberJoinedEvent) {
     Members members = this.memberService.findById(matchMemberJoinedEvent.memberId());
     MatchingRoom matchingRoom = this.matchingRoomRepository.findById(matchMemberJoinedEvent.roomId()).orElseThrow(NoSuchMatchingRoomException::new);
@@ -134,7 +145,12 @@ public class MatchingRoomService {
     }
     this.memberMatchingRoomChargingInfoRepository.saveAll(existMembers);
   }
-
+  public void updateExistMembersChargeForManual(List<MemberMatchingRoomChargingInfo> existMembers, int charge) {
+    for (MemberMatchingRoomChargingInfo memberMatchingRoomChargingInfo : existMembers) {
+      memberMatchingRoomChargingInfo.setCharge(charge);
+    }
+    this.memberMatchingRoomChargingInfoRepository.saveAll(existMembers);
+  }
   public void leaveMemberFromMatchingRoom(MatchMemberCancelledEvent matchMemberCancelledEvent) {
     Members members = this.memberService.findById(matchMemberCancelledEvent.memberId());
     MatchingRoom matchingRoom = this.matchingRoomRepository.findById(matchMemberCancelledEvent.roomId()).orElseThrow(NoSuchMatchingRoomException::new);


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #61 
Close 

## 🚀 작업 내용

- 수동매칭 CRUD를 구현하였습니다, 이슈에서 작성했던 대로 
자동 매칭과 수동 매칭의 차이점은 방 생성 방식이고, 사용자가 직접 매칭방에 참여하는 형태라서, 
별도의 알고리즘 서비스 없이 ManualMatchingService를 추가하여 구현하였습니다

- 매칭방 생성 로직은 match_room 테이블에 새로운 매칭 방을 추가하고, 방을 생성한 사용자를 방장으로 지정해주었습니다

- 매칭방 참여 로직에는 인원 초과, 태그 불일치, 사용자가 이미 참여한 경우, 본인이 생성한 방에 참여를 요청할 경우 등을 예외처리 해주었습니다
참여 후 match_room 테이블을 업데이트하여 현재 참가 인원 및 정산금액을 반영하도록 하였고,

- 마지막으로 방장 취소 및 방 삭제 처리는 방장이 나갈 경우 새로운 방장을 자동으로 선정하며, 
만약 방에 남은 참가자가 없는 경우, 방을 CANCELLED 상태로 변경하여 소프트 딜리트 방식으로 구현하였습니다

## 📸 스크린샷

먼저 수동 매칭방 생성 테스트입니다
![image](https://github.com/user-attachments/assets/6592699c-cacd-45bb-816c-4f0d46e82e23)
사용자가 제목, 출발지, 도착지, 추가 설명, 출발시간, 예상 요금, 태그 등등을 설정해서 수동 매칭방을 생성합니다
![image](https://github.com/user-attachments/assets/8a4889ec-4b81-404a-850e-5abbc0ee35d3)
DB에 잘 들어가는 것도 확인했고
![image](https://github.com/user-attachments/assets/f87321c0-430a-450e-8cf3-eecce4050ed8)
동일 조건으로 매칭방 생성시 중복 예외처리 하였습니다

---

두번째로 수동 매칭방 참여 테스트입니다
![image](https://github.com/user-attachments/assets/fa19ad9e-6bcd-40e0-af60-c528c9a52393)
![image](https://github.com/user-attachments/assets/0697ca9f-e2b4-45a7-b6bd-4a3e5e214848)
DB에 잘 들어가는 것도 확인했고
<img width="686" alt="image" src="https://github.com/user-attachments/assets/50ca7ac8-1b45-4d3c-8dba-af89953cc34e" />
방을 생성한 유저가 참여요청시, 정상적이지 않은 플로우지만 백엔드 측에서도 예외처리가 되도록 하였습니다

---

마지막으로 수동 매칭방 퇴장 및 삭제 테스트입니다
![image](https://github.com/user-attachments/assets/1e33f1ff-4197-403a-900c-ec7f273538d6)
방장인 유저가 퇴장시(다른 참여자가 남아있다는 가정) 이렇게 소프트 딜리트로 LEFT로 payment_Status가 변경되게 됩니다
![image](https://github.com/user-attachments/assets/d7e90ff5-002a-4c1b-b67b-94f895308317)
다른 참여자가 남아있는 플로우이기 때문에 방장이 다른 유저로 변경되게 됩니다
![image](https://github.com/user-attachments/assets/bbeca449-4ddc-4be8-bbc8-958624be5ded)
만약 다른 참여자가 남아있지않은 상황에서, 방에 한명 남은 참여자까지 퇴장하게 될시
![image](https://github.com/user-attachments/assets/f0689b87-08ae-4400-8366-ac24e60a4903)
MatchingRoomStatus가 CANCELLED로 방이 소프트 딜리트가 됩니다
![image](https://github.com/user-attachments/assets/5cf0064e-8fc2-45bc-b9b6-590529e381e7)
CANCELLED 상태인 방에 참여 요청시 예외처리까지도 테스트 완료했습니다

## 📢 리뷰 요구사항
수동 매칭 → 자동 매칭 전환 로직은 서비스 단에만 구현을 해놨는데, 10분전에 사용자한테 알림 발행이 필요할거같아
해당 PR 내용 세부사항 수정한 뒤에, 추가적으로 이슈 만들어서 고도화할때 함께 구현하도록 하겠습니다
