### PR TITLE
Feat #73 수동매칭 로직 고도화

### DIFF
--- a/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
+++ b/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
@@ -50,7 +50,6 @@ public class FriendService {
         friendRepository.save(Friends.of(sender, receiver));
 
         notificationService.sendWithPush(
-                sender.getId(),
                 receiver,
                 FRIEND_REQUEST,
                 FRIEND_REQUEST_TITLE,

--- a/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
@@ -6,6 +6,7 @@ import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.GET
 import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.GET_MY_MATCHING_LIST_SUCCESS;
 import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.JOIN_MANUAL_MATCHING_ROOM_SUCCESS;
 import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.LEAVE_MANUAL_MATCHING_ROOM_SUCCESS;
+import static org.springframework.http.HttpStatus.OK;
 
 import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingJoinRequest;
 import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingRequest;
@@ -20,7 +21,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -43,14 +43,14 @@ public class ManualMatchingController {
     @PostMapping("/creation")
     public ApiResponse<Long> createManualMatchingRoom(@CurrentMemberId Long userId, @Valid @RequestBody ManualMatchingRequest request) {
         Long roomId = manualMatchingService.createManualMatchingRoom(userId, request);
-        return ApiResponse.response(HttpStatus.OK, CREATE_MANUAL_MATCHING_ROOM_SUCCESS.getMessage(), roomId);
+        return ApiResponse.response(OK, CREATE_MANUAL_MATCHING_ROOM_SUCCESS.getMessage(), roomId);
     }
 
     @Operation(summary = "수동 매칭방 참여")
     @PostMapping("/join")
     public ApiResponse<Void> joinManualMatchingRoom(@CurrentMemberId Long userId, @Valid @RequestBody ManualMatchingJoinRequest request) {
         manualMatchingService.joinManualMatchingRoom(userId, request.roomId());
-        return ApiResponse.response(HttpStatus.OK, JOIN_MANUAL_MATCHING_ROOM_SUCCESS.getMessage());
+        return ApiResponse.response(OK, JOIN_MANUAL_MATCHING_ROOM_SUCCESS.getMessage());
     }
 
     @Operation(summary = "수동 매칭 초대 수락")
@@ -58,27 +58,27 @@ public class ManualMatchingController {
     public ApiResponse<Void> acceptInvitation(@RequestParam Long userId, @RequestParam Long matchingRoomId
     ) {
         matchingInvitationService.acceptInvitation(userId, matchingRoomId);
-        return ApiResponse.response(HttpStatus.OK, ACCEPT_MATCHING_INVITE_SUCCESS.getMessage());
+        return ApiResponse.response(OK, ACCEPT_MATCHING_INVITE_SUCCESS.getMessage());
     }
 
     @Operation(summary = "수동 매칭방 퇴장 (방 삭제 포함)")
     @PatchMapping("/exit/{roomId}")
     public ApiResponse<Void> leaveManualMatchingRoom(@CurrentMemberId Long userId, @PathVariable Long roomId) {
         manualMatchingService.leaveManualMatchingRoom(userId, roomId);
-        return ApiResponse.response(HttpStatus.OK, LEAVE_MANUAL_MATCHING_ROOM_SUCCESS.getMessage());
+        return ApiResponse.response(OK, LEAVE_MANUAL_MATCHING_ROOM_SUCCESS.getMessage());
     }
 
     @Operation(summary = "수동 매칭방 조회")
     @GetMapping("/list")
     public ApiResponse<MatchingRoomListResponse> getManualMatchingList(int pageNumber, int pageSize) {
         Page<MatchingRoomResponse> rooms = manualMatchingService.getManualMatchingList(pageNumber, pageSize);
-        return ApiResponse.response(HttpStatus.OK, GET_MANUAL_MATCHING_LIST_SUCCESS.getMessage(), MatchingRoomListResponse.of(rooms));
+        return ApiResponse.response(OK, GET_MANUAL_MATCHING_LIST_SUCCESS.getMessage(), MatchingRoomListResponse.of(rooms));
     }
 
     @Operation(summary = "나의 매칭(수동) 조회")
     @GetMapping("/my-list")
     public ApiResponse<MatchingRoomListResponse> getMyMatchingList(@CurrentMemberId Long userId, int pageNumber, int pageSize) {
         Page<MatchingRoomResponse> rooms = manualMatchingService.getMyMatchingList(userId, pageNumber, pageSize);
-        return ApiResponse.response(HttpStatus.OK, GET_MY_MATCHING_LIST_SUCCESS.getMessage(), MatchingRoomListResponse.of(rooms));
+        return ApiResponse.response(OK, GET_MY_MATCHING_LIST_SUCCESS.getMessage(), MatchingRoomListResponse.of(rooms));
     }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
@@ -55,7 +55,7 @@ public class ManualMatchingController {
 
     @Operation(summary = "수동 매칭 초대 수락")
     @PostMapping("/invite/accept")
-    public ApiResponse<Void> acceptInvitation(@CurrentMemberId Long userId, @RequestParam Long matchingRoomId
+    public ApiResponse<Void> acceptInvitation(@RequestParam Long userId, @RequestParam Long matchingRoomId
     ) {
         matchingInvitationService.acceptInvitation(userId, matchingRoomId);
         return ApiResponse.response(HttpStatus.OK, ACCEPT_MATCHING_INVITE_SUCCESS.getMessage());

--- a/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
@@ -55,9 +55,9 @@ public class ManualMatchingController {
 
     @Operation(summary = "수동 매칭 초대 수락")
     @PostMapping("/invite/accept")
-    public ApiResponse<Void> acceptInvitation(@RequestParam Long userId, @RequestParam Long matchingRoomId
+    public ApiResponse<Void> acceptInvitation(@RequestParam Long userId, @RequestParam Long matchingRoomId, @RequestParam String notificationId
     ) {
-        matchingInvitationService.acceptInvitation(userId, matchingRoomId);
+        matchingInvitationService.acceptInvitation(userId, matchingRoomId, notificationId);
         return ApiResponse.response(OK, ACCEPT_MATCHING_INVITE_SUCCESS.getMessage());
     }
 

--- a/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
@@ -1,5 +1,6 @@
 package com.gachtaxi.domain.matching.common.controller;
 
+import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.ACCEPT_MATCHING_INVITE_SUCCESS;
 import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.CREATE_MANUAL_MATCHING_ROOM_SUCCESS;
 import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.GET_MANUAL_MATCHING_LIST_SUCCESS;
 import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.GET_MY_MATCHING_LIST_SUCCESS;
@@ -11,6 +12,7 @@ import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingRequest;
 import com.gachtaxi.domain.matching.common.dto.response.MatchingRoomListResponse;
 import com.gachtaxi.domain.matching.common.dto.response.MatchingRoomResponse;
 import com.gachtaxi.domain.matching.common.service.ManualMatchingService;
+import com.gachtaxi.domain.matching.common.service.MatchingInvitationService;
 import com.gachtaxi.global.auth.jwt.annotation.CurrentMemberId;
 import com.gachtaxi.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,6 +27,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "MANUAL", description = "수동매칭 API")
@@ -34,6 +37,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ManualMatchingController {
 
     private final ManualMatchingService manualMatchingService;
+    private final MatchingInvitationService matchingInvitationService;
 
     @Operation(summary = "수동 매칭방 생성")
     @PostMapping("/creation")
@@ -47,6 +51,14 @@ public class ManualMatchingController {
     public ApiResponse<Void> joinManualMatchingRoom(@CurrentMemberId Long userId, @Valid @RequestBody ManualMatchingJoinRequest request) {
         manualMatchingService.joinManualMatchingRoom(userId, request.roomId());
         return ApiResponse.response(HttpStatus.OK, JOIN_MANUAL_MATCHING_ROOM_SUCCESS.getMessage());
+    }
+
+    @Operation(summary = "수동 매칭 초대 수락")
+    @PostMapping("/invite/accept")
+    public ApiResponse<Void> acceptInvitation(@CurrentMemberId Long userId, @RequestParam Long matchingRoomId
+    ) {
+        matchingInvitationService.acceptInvitation(userId, matchingRoomId);
+        return ApiResponse.response(HttpStatus.OK, ACCEPT_MATCHING_INVITE_SUCCESS.getMessage());
     }
 
     @Operation(summary = "수동 매칭방 퇴장 (방 삭제 포함)")

--- a/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
@@ -55,7 +55,7 @@ public class ManualMatchingController {
 
     @Operation(summary = "수동 매칭 초대 수락")
     @PostMapping("/invite/accept")
-    public ApiResponse<Void> acceptInvitation(@RequestParam Long userId, @RequestParam Long matchingRoomId, @RequestParam String notificationId
+    public ApiResponse<Void> acceptInvitation(@CurrentMemberId Long userId, @RequestParam Long matchingRoomId, @RequestParam String notificationId
     ) {
         matchingInvitationService.acceptInvitation(userId, matchingRoomId, notificationId);
         return ApiResponse.response(OK, ACCEPT_MATCHING_INVITE_SUCCESS.getMessage());

--- a/src/main/java/com/gachtaxi/domain/matching/common/controller/ResponseMessage.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/controller/ResponseMessage.java
@@ -21,7 +21,8 @@ public enum ResponseMessage {
   LEAVE_MANUAL_MATCHING_ROOM_SUCCESS("매칭방 퇴장이 완료되었습니다."),
   CONVERT_TO_AUTO_MATCHING_SUCCESS("자동 매칭으로 전환되었습니다."),
   GET_MANUAL_MATCHING_LIST_SUCCESS("수동 매칭방 조회에 성공했습니다."),
-  GET_MY_MATCHING_LIST_SUCCESS("내 매칭방 조회에 성공했습니다.");
+  GET_MY_MATCHING_LIST_SUCCESS("내 매칭방 조회에 성공했습니다."),
+  ACCEPT_MATCHING_INVITE_SUCCESS("매칭방 초대 수락에 성공했습니다");
 
   private final String message;
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingRequest.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingRequest.java
@@ -9,8 +9,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public record ManualMatchingRequest(
-        @NotBlank
-        String title,
 
         String description,
 

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingRequest.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingRequest.java
@@ -28,7 +28,10 @@ public record ManualMatchingRequest(
         int totalCharge,
 
         @Schema(description = "매칭 태그")
-        List<String> criteria
+        List<String> criteria,
+
+        @Schema(description = "초대할 친구 닉네임 리스트")
+        List<String> friendNicknames
 ) {
     public List<Tags> getCriteria() {
         return this.criteria.stream()

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingRequest.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingRequest.java
@@ -13,27 +13,43 @@ public record ManualMatchingRequest(
         String description,
 
         @NotBlank
-        String departure,
+        String startName,
 
         @NotBlank
-        String destination,
+        String destinationName,
 
         @NotNull
         LocalDateTime departureTime,
 
         @Schema(description = "예상 요금")
         @Min(value = 0)
-        int totalCharge,
+        int expectedTotalCharge,
 
         @Schema(description = "매칭 태그")
         List<String> criteria,
 
         @Schema(description = "초대할 친구 닉네임 리스트")
-        List<String> friendNicknames
+        List<String> members
 ) {
     public List<Tags> getCriteria() {
         return this.criteria.stream()
                 .map(Tags::valueOf)
                 .toList();
+    }
+
+    public List<String> getFriendNicknames() {
+        return members;
+    }
+
+    public int getTotalCharge() {
+        return expectedTotalCharge;
+    }
+
+    public String getDeparture() {
+        return startName;
+    }
+
+    public String getDestination() {
+        return destinationName;
     }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingRoomResponse.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingRoomResponse.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public record MatchingRoomResponse(
         Long roomId,
-        String title,
+        String description,
         String departure,
         String destination,
         LocalDateTime departureTime,
@@ -17,7 +17,7 @@ public record MatchingRoomResponse(
     public static MatchingRoomResponse from(MatchingRoom matchingRoom) {
         return new MatchingRoomResponse(
                 matchingRoom.getId(),
-                matchingRoom.getTitle(),
+                matchingRoom.getDescription(),
                 matchingRoom.getDeparture(),
                 matchingRoom.getDestination(),
                 matchingRoom.getDepartureTime(),

--- a/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
@@ -3,6 +3,7 @@ package com.gachtaxi.domain.matching.common.entity;
 import com.gachtaxi.domain.matching.algorithm.dto.FindRoomResult;
 import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomStatus;
 import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomType;
+import com.gachtaxi.domain.matching.common.exception.MatchingRoomAlreadyFullException;
 import com.gachtaxi.domain.matching.event.dto.kafka_topic.MatchRoomCreatedEvent;
 import com.gachtaxi.domain.matching.common.entity.enums.Tags;
 import com.gachtaxi.domain.members.entity.Members;
@@ -152,5 +153,13 @@ public class MatchingRoom extends BaseEntity {
     return this.matchingRoomTagInfo.stream()
             .map(tagInfo -> tagInfo.getTags().name())
             .toList();
+  }
+
+  public void addMember(Members member) {
+    if (this.getCurrentMemberCount() >= this.capacity) {
+      throw new MatchingRoomAlreadyFullException();
+    }
+    MemberMatchingRoomChargingInfo memberInfo = MemberMatchingRoomChargingInfo.notPayedOf(this, member);
+    this.memberMatchingRoomChargingInfo.add(memberInfo);
   }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
@@ -3,7 +3,6 @@ package com.gachtaxi.domain.matching.common.entity;
 import com.gachtaxi.domain.matching.algorithm.dto.FindRoomResult;
 import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomStatus;
 import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomType;
-import com.gachtaxi.domain.matching.common.exception.MatchingRoomAlreadyFullException;
 import com.gachtaxi.domain.matching.event.dto.kafka_topic.MatchRoomCreatedEvent;
 import com.gachtaxi.domain.matching.common.entity.enums.Tags;
 import com.gachtaxi.domain.members.entity.Members;
@@ -49,7 +48,7 @@ public class MatchingRoom extends BaseEntity {
   @Setter
   private Members roomMaster;
 
-  @Column(name = "title", nullable = false)
+  @Column(name = "title")
   @Getter
   private String title;
 
@@ -153,13 +152,5 @@ public class MatchingRoom extends BaseEntity {
     return this.matchingRoomTagInfo.stream()
             .map(tagInfo -> tagInfo.getTags().name())
             .toList();
-  }
-
-  public void addMember(Members member) {
-    if (this.getCurrentMemberCount() >= this.capacity) {
-      throw new MatchingRoomAlreadyFullException();
-    }
-    MemberMatchingRoomChargingInfo memberInfo = MemberMatchingRoomChargingInfo.notPayedOf(this, member);
-    this.memberMatchingRoomChargingInfo.add(memberInfo);
   }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
@@ -54,6 +54,7 @@ public class MatchingRoom extends BaseEntity {
   private String title;
 
   @Column(name = "description", nullable = false)
+  @Getter
   private String description;
 
   @ManyToOne(fetch = FetchType.LAZY)
@@ -117,11 +118,10 @@ public class MatchingRoom extends BaseEntity {
         .build();
   }
 
-  public static MatchingRoom manualOf(Members roomMaster, String departure, String destination, String title, String description, int maxCapacity, int totalCharge, LocalDateTime departureTime) {
+  public static MatchingRoom manualOf(Members roomMaster, String departure, String destination, String description, int maxCapacity, int totalCharge, LocalDateTime departureTime) {
     return MatchingRoom.builder()
             .capacity(4)
             .roomMaster(roomMaster)
-            .title(title)
             .description(description)
             .departure(departure)
             .destination(destination)

--- a/src/main/java/com/gachtaxi/domain/matching/common/exception/ErrorMessage.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/exception/ErrorMessage.java
@@ -18,7 +18,9 @@ public enum ErrorMessage {
   NOT_FOUND_PAGE("페이지 번호는 0 이상이어야 합니다."),
   ALREADY_IN_MATCHING_ROOM("이미 매칭 방에 참가한 멤버입니다."),
   MATCHING_ROOM_NOT_JOIN_OWN("자신이 만든 매칭 방에는 참가할 수 없습니다."),
-  NOT_EQUAL_START_DESTINATION("출발지와 도착지는 같을 수 없습니다.");
+  NOT_EQUAL_START_DESTINATION("출발지와 도착지는 같을 수 없습니다."),
+  NO_SUCH_INVITATION("해당 수동매칭 초대가 존재하지 않습니다."),
+  MATCHING_ALREADY_ROOM_FULL("매칭 방이 이미 꽉 찼습니다.");
 
   private final String message;
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/exception/MatchingRoomAlreadyFullException.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/exception/MatchingRoomAlreadyFullException.java
@@ -1,0 +1,13 @@
+package com.gachtaxi.domain.matching.common.exception;
+
+import static com.gachtaxi.domain.matching.common.exception.ErrorMessage.MATCHING_ALREADY_ROOM_FULL;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import com.gachtaxi.global.common.exception.BaseException;
+
+public class MatchingRoomAlreadyFullException extends BaseException {
+
+      public MatchingRoomAlreadyFullException() {
+          super(BAD_REQUEST, MATCHING_ALREADY_ROOM_FULL.getMessage());
+      }
+}

--- a/src/main/java/com/gachtaxi/domain/matching/common/exception/NoSuchInvitationException.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/exception/NoSuchInvitationException.java
@@ -1,0 +1,12 @@
+package com.gachtaxi.domain.matching.common.exception;
+
+import static com.gachtaxi.domain.matching.common.exception.ErrorMessage.NO_SUCH_INVITATION;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import com.gachtaxi.global.common.exception.BaseException;
+
+public class NoSuchInvitationException extends BaseException {
+    public NoSuchInvitationException() {
+        super(NOT_FOUND, NO_SUCH_INVITATION.getMessage());
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -54,23 +54,23 @@ public class ManualMatchingService {
             throw new DuplicatedMatchingRoomException();
         }
 
-        if (request.departure().equals(request.destination())) {
+        if (request.getDeparture().equals(request.getDestination())) {
             throw new NotEqualStartAndDestinationException();
         }
 
         MatchingRoom matchingRoom = MatchingRoom.manualOf(
                 roomMaster,
-                request.departure(),
-                request.destination(),
+                request.getDeparture(),
+                request.getDestination(),
                 request.description(),
                 4,
-                request.totalCharge(),
+                request.getTotalCharge(),
                 request.departureTime()
         );
 
         MatchingRoom savedMatchingRoom = matchingRoomRepository.save(matchingRoom);
 
-        matchingInvitationService.sendMatchingInvitation(roomMaster, request.friendNicknames());
+        matchingInvitationService.sendMatchingInvitation(roomMaster, request.getFriendNicknames());
 
         matchingRoomService.saveMatchingRoomTagInfoForManual(savedMatchingRoom, request.getCriteria());
         matchingRoomService.saveRoomMasterChargingInfoForManual(savedMatchingRoom, roomMaster);

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -62,7 +62,6 @@ public class ManualMatchingService {
                 roomMaster,
                 request.departure(),
                 request.destination(),
-                request.title(),
                 request.description(),
                 4,
                 request.totalCharge(),

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -39,6 +39,7 @@ public class ManualMatchingService {
 
     private final MemberService memberService;
     private final MatchingRoomService matchingRoomService;
+    private final MatchingInvitationService matchingInvitationService;
     private final MatchingRoomRepository matchingRoomRepository;
     private final MemberMatchingRoomChargingInfoRepository memberMatchingRoomChargingInfoRepository;
 
@@ -69,6 +70,8 @@ public class ManualMatchingService {
         );
 
         MatchingRoom savedMatchingRoom = matchingRoomRepository.save(matchingRoom);
+
+        matchingInvitationService.sendMatchingInvitation(roomMaster, request.friendNicknames());
 
         matchingRoomService.saveMatchingRoomTagInfoForManual(savedMatchingRoom, request.getCriteria());
         matchingRoomService.saveRoomMasterChargingInfoForManual(savedMatchingRoom, roomMaster);

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -70,7 +70,7 @@ public class ManualMatchingService {
 
         MatchingRoom savedMatchingRoom = matchingRoomRepository.save(matchingRoom);
 
-        matchingInvitationService.sendMatchingInvitation(roomMaster, request.getFriendNicknames());
+        matchingInvitationService.sendMatchingInvitation(roomMaster, request.getFriendNicknames(), savedMatchingRoom.getId());
 
         matchingRoomService.saveMatchingRoomTagInfoForManual(savedMatchingRoom, request.getCriteria());
         matchingRoomService.saveRoomMasterChargingInfoForManual(savedMatchingRoom, roomMaster);

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/MatchingInvitationService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/MatchingInvitationService.java
@@ -9,7 +9,9 @@ import com.gachtaxi.domain.matching.common.repository.MatchingRoomRepository;
 import com.gachtaxi.domain.members.entity.Members;
 import com.gachtaxi.domain.members.repository.MemberRepository;
 import com.gachtaxi.domain.members.service.MemberService;
+import com.gachtaxi.domain.notification.entity.enums.NotificationType;
 import com.gachtaxi.domain.notification.entity.payload.MatchingInvitePayload;
+import com.gachtaxi.domain.notification.repository.NotificationRepository;
 import com.gachtaxi.domain.notification.service.NotificationService;
 import jakarta.transaction.Transactional;
 import java.util.List;
@@ -24,6 +26,7 @@ public class MatchingInvitationService {
     private final MemberService memberService;
     private final MemberRepository memberRepository;
     private final MatchingRoomRepository matchingRoomRepository;
+    private final NotificationRepository notificationRepository;
 
     /*
       수동 매칭시 친구 초대
@@ -40,7 +43,6 @@ public class MatchingInvitationService {
 
         for (Members friend : friends) {
             notificationService.sendWithPush(
-                    sender.getId(),
                     friend,
                     MATCH_INVITE,
                     MATCHING_INVITE_TITLE,
@@ -59,7 +61,7 @@ public class MatchingInvitationService {
         MatchingRoom matchingRoom = matchingRoomRepository.findById(matchingRoomId)
                 .orElseThrow(NoSuchMatchingRoomException::new);
 
-        if (!notificationService.hasReceivedMatchingInvite(userId)) {
+        if (notificationRepository.countByReceiverIdAndType(userId, NotificationType.MATCH_INVITE) == 0) {
             throw new NoSuchInvitationException();
         }
 

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/MatchingInvitationService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/MatchingInvitationService.java
@@ -1,0 +1,69 @@
+package com.gachtaxi.domain.matching.common.service;
+
+import static com.gachtaxi.domain.notification.entity.enums.NotificationType.MATCH_INVITE;
+
+import com.gachtaxi.domain.matching.common.entity.MatchingRoom;
+import com.gachtaxi.domain.matching.common.exception.NoSuchInvitationException;
+import com.gachtaxi.domain.matching.common.exception.NoSuchMatchingRoomException;
+import com.gachtaxi.domain.matching.common.repository.MatchingRoomRepository;
+import com.gachtaxi.domain.members.entity.Members;
+import com.gachtaxi.domain.members.repository.MemberRepository;
+import com.gachtaxi.domain.members.service.MemberService;
+import com.gachtaxi.domain.notification.entity.payload.MatchingInvitePayload;
+import com.gachtaxi.domain.notification.service.NotificationService;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MatchingInvitationService {
+    private final NotificationService notificationService;
+    private final MemberService memberService;
+    private final MemberRepository memberRepository;
+    private final MatchingRoomRepository matchingRoomRepository;
+
+    /*
+      수동 매칭시 친구 초대
+    */
+    public static final String MATCHING_INVITE_TITLE = "수동 매칭 초대";
+    public static final String MATCHING_INVITE_CONTENT = "%s 님이 수동 매칭 초대를 보냈습니다.";
+
+    public void sendMatchingInvitation(Members sender, List<String> friendNicknames) {
+        if (friendNicknames == null || friendNicknames.isEmpty()) {
+            return;
+        }
+
+        List<Members> friends = memberRepository.findByNicknameIn(friendNicknames);
+
+        for (Members friend : friends) {
+            notificationService.sendWithPush(
+                    sender.getId(),
+                    friend,
+                    MATCH_INVITE,
+                    MATCHING_INVITE_TITLE,
+                    String.format(MATCHING_INVITE_CONTENT, sender.getNickname()),
+                    MatchingInvitePayload.from(sender.getNickname())
+            );
+        }
+    }
+
+    /*
+      수동 매칭시 친구 초대 수락
+    */
+    @Transactional
+    public void acceptInvitation(Long userId, Long matchingRoomId) {
+        Members member = memberService.findById(userId);
+        MatchingRoom matchingRoom = matchingRoomRepository.findById(matchingRoomId)
+                .orElseThrow(NoSuchMatchingRoomException::new);
+
+        if (!notificationService.hasReceivedMatchingInvite(userId)) {
+            throw new NoSuchInvitationException();
+        }
+
+        matchingRoom.addMember(member);
+        matchingRoomRepository.save(matchingRoom);
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/members/repository/MemberRepository.java
+++ b/src/main/java/com/gachtaxi/domain/members/repository/MemberRepository.java
@@ -2,6 +2,7 @@ package com.gachtaxi.domain.members.repository;
 
 import com.gachtaxi.domain.members.entity.Members;
 import com.gachtaxi.domain.members.entity.enums.UserStatus;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -23,4 +24,6 @@ public interface MemberRepository extends JpaRepository<Members, Long> {
     Optional<Members> findByNicknameAndStatus(String nickname, UserStatus status);
 
     Optional<Members> findByEmailAndStatus(String email, UserStatus status);
+
+    List<Members> findByNicknameIn(List<String> nicknames);
 }

--- a/src/main/java/com/gachtaxi/domain/notification/entity/enums/NotificationType.java
+++ b/src/main/java/com/gachtaxi/domain/notification/entity/enums/NotificationType.java
@@ -1,5 +1,5 @@
 package com.gachtaxi.domain.notification.entity.enums;
 
 public enum NotificationType {
-    MATCH_START, MATCH_FINISH, FRIEND_REQUEST
+    MATCH_START, MATCH_FINISH, FRIEND_REQUEST, MATCH_INVITE
 }

--- a/src/main/java/com/gachtaxi/domain/notification/entity/payload/MatchingInvitePayload.java
+++ b/src/main/java/com/gachtaxi/domain/notification/entity/payload/MatchingInvitePayload.java
@@ -1,0 +1,19 @@
+package com.gachtaxi.domain.notification.entity.payload;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MatchingInvitePayload extends NotificationPayload {
+    private String senderNickname;
+
+    public static MatchingInvitePayload from(String senderNickname) {
+        return MatchingInvitePayload.builder()
+                .senderNickname(senderNickname)
+                .build();
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/notification/entity/payload/MatchingInvitePayload.java
+++ b/src/main/java/com/gachtaxi/domain/notification/entity/payload/MatchingInvitePayload.java
@@ -10,10 +10,12 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MatchingInvitePayload extends NotificationPayload {
     private String senderNickname;
+    private Long matchingRoomId;
 
-    public static MatchingInvitePayload from(String senderNickname) {
+    public static MatchingInvitePayload from(String senderNickname, Long matchingRoomId) {
         return MatchingInvitePayload.builder()
                 .senderNickname(senderNickname)
+                .matchingRoomId(matchingRoomId)
                 .build();
     }
 }

--- a/src/main/java/com/gachtaxi/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/gachtaxi/domain/notification/repository/NotificationRepository.java
@@ -2,6 +2,7 @@ package com.gachtaxi.domain.notification.repository;
 
 import com.gachtaxi.domain.notification.entity.Notification;
 import com.gachtaxi.domain.notification.entity.enums.NotificationStatus;
+import com.gachtaxi.domain.notification.entity.enums.NotificationType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.mongodb.repository.MongoRepository;
@@ -11,4 +12,6 @@ public interface NotificationRepository extends MongoRepository<Notification, Lo
     Integer countAllByReceiverIdAndStatus(Long receiverId, NotificationStatus status);
 
     Slice<Notification> findAllByReceiverId(Long receiverId, Pageable pageable);
+
+    boolean existsByReceiverIdAndType(Long receiverId, NotificationType type);
 }

--- a/src/main/java/com/gachtaxi/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/gachtaxi/domain/notification/repository/NotificationRepository.java
@@ -13,5 +13,5 @@ public interface NotificationRepository extends MongoRepository<Notification, Lo
 
     Slice<Notification> findAllByReceiverId(Long receiverId, Pageable pageable);
 
-    boolean existsByReceiverIdAndType(Long receiverId, NotificationType type);
+    int countByReceiverIdAndType(Long receiverId, NotificationType type);
 }

--- a/src/main/java/com/gachtaxi/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/gachtaxi/domain/notification/service/NotificationService.java
@@ -81,7 +81,7 @@ public class NotificationService {
         notificationRepository.deleteById(notificationId);
     }
 
-    private Notification find(String notificationId) {
+    public Notification find(String notificationId) {
         return notificationRepository.findById(notificationId)
                 .orElseThrow(NotificationNotFoundException::new);
     }

--- a/src/main/java/com/gachtaxi/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/gachtaxi/domain/notification/service/NotificationService.java
@@ -61,15 +61,16 @@ public class NotificationService {
         return NotificationInfoResponse.of(count, false);
     }
 
-    public void sendWithPush(Long senderId, Members receiver, NotificationType type, String title, String content, NotificationPayload payload) {
-        Notification notification = Notification.of(senderId, type, content, payload);
+    public void sendWithPush(Members receiver, NotificationType type, String title, String content, NotificationPayload payload) {
+        Notification notification = Notification.of(receiver.getId(), type, content, payload);
 
         notificationRepository.save(notification);
-        fcmService.sendNotification(receiver.getFcmToken(), title, notification.getContent());
+        // todo : 앱으로 마이그레이션 후 주석 해제
+//        fcmService.sendNotification(receiver.getFcmToken(), title, notification.getContent());
     }
 
-    public void sendWithOutPush(Long senderId, Members receiver, NotificationType type, String content, NotificationPayload payload) {
-        Notification notification = Notification.of(senderId, type, content, payload);
+    public void sendWithOutPush(Members receiver, NotificationType type, String content, NotificationPayload payload) {
+        Notification notification = Notification.of(receiver.getId(), type, content, payload);
 
         notificationRepository.save(notification);
     }
@@ -91,11 +92,5 @@ public class NotificationService {
         if (!notification.getReceiverId().equals(receiverId)) {
             throw new MemberNotMatchException();
         }
-    }
-
-    public boolean hasReceivedMatchingInvite(Long userId) {
-        return notificationRepository.existsByReceiverIdAndType(
-                userId, NotificationType.MATCH_INVITE
-        );
     }
 }

--- a/src/main/java/com/gachtaxi/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/gachtaxi/domain/notification/service/NotificationService.java
@@ -92,4 +92,10 @@ public class NotificationService {
             throw new MemberNotMatchException();
         }
     }
+
+    public boolean hasReceivedMatchingInvite(Long userId) {
+        return notificationRepository.existsByReceiverIdAndType(
+                userId, NotificationType.MATCH_INVITE
+        );
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #70 
Close #

## 🚀 작업 내용

- 예상 유저 플로우는 수동 매칭방 생성시, 같이 매칭방에 참가할 유저에게 초대를 보냅니다
초대를 받은 유저는 매칭 초대를 수락하게 되면, 해당 수동매칭방에 참가까지 완료가 되는 플로우로 구현하였습니다

- 수동매칭시 친구 초대 로직에 아래 내용을 포함하여, 친구 리스트가 null값이 허용되니까, 만약 비어있다면 sendMatchingInvitation 메서드가 실행되지 않도록하여 혼자서 수동 매칭방을 생성하는 기존 플로우로 이해해주시면 됩니다
```java
if (friendNicknames == null || friendNicknames.isEmpty()) {
            return;
        }
```

- 매칭수락시 파라미터로 방 ID와 알림 ID를 입력해서 방 참여 완료까지 테스트 완료했습니다
매칭 수락시의 예외처리는, 초대 여부 확인, 매칭방 존재 여부, 매칭방 정원 초과, 이미 참여한 매칭방 등등입니다 
해당 내용의 예외처리들도 테스트 완료했습니다

- [x] 수동 매칭 시작시, 친구로 원하는 사람 친구추가


아래 내용은 주영님이 작업하신 내용이 머지됨에 따라서 별도의 이슈에서 새로 브랜치를 만들어서 진행해보도록 하겠습니다
1. 매칭시 블랙리스트 예외처리
2. MatchingRoom 생성시 채팅방 함께 생성
3. 수동 매칭방 조회, 나의 매칭(수동) 조회시 채팅방 ID 함께 반환


## 📸 스크린샷
<img width="957" alt="image" src="https://github.com/user-attachments/assets/fc7799b1-8f3f-4a07-8f3d-d7998ac5b175" />
수동매칭 생성시 유저 초대 후

![image](https://github.com/user-attachments/assets/a63aa135-3fe9-4aef-9a6a-b06bbe96c986)
해당 유저가 초대를 수락하면 

<img width="1275" alt="image" src="https://github.com/user-attachments/assets/73fa62a4-131d-439c-95a0-4284f079ea22" />
memberMatchingRoomChargingInfo에 올바르게 DB 값이 들어가는 것도 확인했습니다

![image](https://github.com/user-attachments/assets/12db2b8c-ef76-4880-8834-abec8cf5b987)
만약 알림 Id가 잘못된 값이 입력된다면, 던져주는 예외처리 또한 테스트 완료했습니다

---

<img width="472" alt="image" src="https://github.com/user-attachments/assets/4158bd74-c443-4e94-a687-ba1e6d2a8ea9" />

몽고 DB에서 receiverId 가 senderId(1)로 바꿔서 들어가는 문제

## 📢 리뷰 요구사항

강혁님 코멘트 내용 반영해서 아직 웹 상태라서 FCM 토큰 오류 방지를 위해 , fcmService.sendNotification() 메서드는 주석처리 했습니다

추후에 수동 매칭방이 생성된 이후에도 초대를 할 수 있도록 리팩토링을 하면 유저 경험 측면에서 좋을거같은데,  현재는 이후에도 별도의 모달창을 날려주는건 아니라고 생각해서 기존에 우석님이 구현하셨던 친구추가와 비슷한 로직으로 구현하였습니다  

초대 여부 확인, 매칭방 존재 여부, 매칭방 정원 초과 등등 예외처리 해주었는데, 추가적으로 고려할 수 있는 예외가 있는지 피드백 부탁드립니다

