### PR TITLE
Refactor #79 수동매칭 블랙리스트 및 채팅방 설정

### DIFF
--- a/src/main/java/com/gachtaxi/domain/chat/service/ChattingParticipantService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChattingParticipantService.java
@@ -6,14 +6,11 @@ import com.gachtaxi.domain.chat.entity.ChattingParticipant;
 import com.gachtaxi.domain.chat.entity.ChattingRoom;
 import com.gachtaxi.domain.chat.entity.enums.MessageType;
 import com.gachtaxi.domain.chat.exception.ChattingParticipantNotFoundException;
-import com.gachtaxi.domain.chat.exception.ChattingRoomNotFoundException;
 import com.gachtaxi.domain.chat.exception.DuplicateSubscribeException;
 import com.gachtaxi.domain.chat.redis.RedisChatPublisher;
 import com.gachtaxi.domain.chat.repository.ChattingMessageMongoRepository;
 import com.gachtaxi.domain.chat.repository.ChattingParticipantRepository;
-import com.gachtaxi.domain.chat.repository.ChattingRoomRepository;
 import com.gachtaxi.domain.members.entity.Members;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.listener.ChannelTopic;
@@ -28,10 +25,8 @@ public class ChattingParticipantService {
 
     private final ChattingParticipantRepository chattingParticipantRepository;
     private final ChattingMessageMongoRepository chattingMessageMongoRepository;
-    private final ChattingRoomRepository chattingRoomRepository;
     private final ChattingRedisService chattingRedisService;
     private final RedisChatPublisher redisChatPublisher;
-    private final ChattingRoomService chattingRoomService;
 
     @Value("${chat.topic}")
     public String chatTopic;
@@ -89,18 +84,5 @@ public class ChattingParticipantService {
         ChatMessage chatMessage = ChatMessage.of(roomId, senderId, senderName, range, MessageType.READ);
 
         redisChatPublisher.publish(topic, chatMessage);
-    }
-
-    @Transactional
-    public void joinChattingRoom(Members user, Long chattingRoomId) {
-        ChattingRoom chattingRoom = chattingRoomRepository.findById(chattingRoomId)
-                .orElseThrow(ChattingRoomNotFoundException::new);
-
-        if (chattingParticipantRepository.findByChattingRoomAndMembers(chattingRoom, user).isPresent()) {
-            return;
-        }
-
-        ChattingParticipant chattingParticipant = ChattingParticipant.of(chattingRoom, user);
-        chattingParticipantRepository.save(chattingParticipant);
     }
 }

--- a/src/main/java/com/gachtaxi/domain/chat/service/ChattingRoomService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChattingRoomService.java
@@ -11,6 +11,7 @@ import com.gachtaxi.domain.chat.entity.enums.MessageType;
 import com.gachtaxi.domain.chat.exception.ChattingRoomNotFoundException;
 import com.gachtaxi.domain.chat.redis.RedisChatPublisher;
 import com.gachtaxi.domain.chat.repository.ChattingMessageRepository;
+import com.gachtaxi.domain.chat.repository.ChattingParticipantRepository;
 import com.gachtaxi.domain.chat.repository.ChattingRoomRepository;
 import com.gachtaxi.domain.members.entity.Members;
 import com.gachtaxi.domain.members.service.MemberService;
@@ -34,6 +35,7 @@ public class ChattingRoomService {
 
     private final ChattingRoomRepository chattingRoomRepository;
     private final ChattingMessageRepository chattingMessageRepository;
+    private final ChattingParticipantRepository chattingParticipantRepository;
     private final ChattingParticipantService chattingParticipantService;
     private final MemberService memberService;
     private final RedisChatPublisher redisChatPublisher;
@@ -116,4 +118,15 @@ public class ChattingRoomService {
         redisChatPublisher.publish(topic, chatMessage);
     }
 
+    @Transactional
+    public ChattingRoom create(Members roomMaster) {
+
+        ChattingRoom chattingRoom = ChattingRoom.builder().build();
+        ChattingRoom savedChattingRoom = chattingRoomRepository.save(chattingRoom);
+
+        ChattingParticipant chattingParticipant = ChattingParticipant.of(savedChattingRoom, roomMaster);
+        chattingParticipantRepository.save(chattingParticipant);
+
+        return savedChattingRoom;
+    }
 }

--- a/src/main/java/com/gachtaxi/domain/chat/service/ChattingRoomService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChattingRoomService.java
@@ -11,7 +11,6 @@ import com.gachtaxi.domain.chat.entity.enums.MessageType;
 import com.gachtaxi.domain.chat.exception.ChattingRoomNotFoundException;
 import com.gachtaxi.domain.chat.redis.RedisChatPublisher;
 import com.gachtaxi.domain.chat.repository.ChattingMessageRepository;
-import com.gachtaxi.domain.chat.repository.ChattingParticipantRepository;
 import com.gachtaxi.domain.chat.repository.ChattingRoomRepository;
 import com.gachtaxi.domain.members.entity.Members;
 import com.gachtaxi.domain.members.service.MemberService;
@@ -35,7 +34,6 @@ public class ChattingRoomService {
 
     private final ChattingRoomRepository chattingRoomRepository;
     private final ChattingMessageRepository chattingMessageRepository;
-    private final ChattingParticipantRepository chattingParticipantRepository;
     private final ChattingParticipantService chattingParticipantService;
     private final MemberService memberService;
     private final RedisChatPublisher redisChatPublisher;
@@ -116,17 +114,5 @@ public class ChattingRoomService {
         ChatMessage chatMessage = ChatMessage.from(chattingMessage);
 
         redisChatPublisher.publish(topic, chatMessage);
-    }
-
-    @Transactional
-    public ChattingRoom create(Members roomMaster) {
-
-        ChattingRoom chattingRoom = ChattingRoom.builder().build();
-        ChattingRoom savedChattingRoom = chattingRoomRepository.save(chattingRoom);
-
-        ChattingParticipant chattingParticipant = ChattingParticipant.of(savedChattingRoom, roomMaster);
-        chattingParticipantRepository.save(chattingParticipant);
-
-        return savedChattingRoom;
     }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
@@ -20,7 +20,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -71,14 +71,14 @@ public class ManualMatchingController {
     @Operation(summary = "수동 매칭방 조회")
     @GetMapping("/list")
     public ApiResponse<MatchingRoomListResponse> getManualMatchingList(int pageNumber, int pageSize) {
-        Page<MatchingRoomResponse> rooms = manualMatchingService.getManualMatchingList(pageNumber, pageSize);
+        Slice<MatchingRoomResponse> rooms = manualMatchingService.getManualMatchingList(pageNumber, pageSize);
         return ApiResponse.response(OK, GET_MANUAL_MATCHING_LIST_SUCCESS.getMessage(), MatchingRoomListResponse.of(rooms));
     }
 
     @Operation(summary = "나의 매칭(수동) 조회")
     @GetMapping("/my-list")
     public ApiResponse<MatchingRoomListResponse> getMyMatchingList(@CurrentMemberId Long userId, int pageNumber, int pageSize) {
-        Page<MatchingRoomResponse> rooms = manualMatchingService.getMyMatchingList(userId, pageNumber, pageSize);
+        Slice<MatchingRoomResponse> rooms = manualMatchingService.getMyMatchingList(userId, pageNumber, pageSize);
         return ApiResponse.response(OK, GET_MY_MATCHING_LIST_SUCCESS.getMessage(), MatchingRoomListResponse.of(rooms));
     }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingPageableResponse.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingPageableResponse.java
@@ -1,7 +1,7 @@
 package com.gachtaxi.domain.matching.common.dto.response;
 
 import lombok.Builder;
-import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 
 
 @Builder
@@ -9,14 +9,14 @@ public record MatchingPageableResponse(
         int pageNumber,
         int pageSize,
         int numberOfElements,
-        boolean last
+        boolean hasNext
 ) {
-    public static MatchingPageableResponse of(Page<?> page) {
+    public static MatchingPageableResponse of(Slice<?> Slice) {
         return MatchingPageableResponse.builder()
-                .pageNumber(page.getNumber())
-                .pageSize(page.getSize())
-                .numberOfElements(page.getNumberOfElements())
-                .last(page.isLast())
+                .pageNumber(Slice.getNumber())
+                .pageSize(Slice.getSize())
+                .numberOfElements(Slice.getNumberOfElements())
+                .hasNext(Slice.hasNext())
                 .build();
     }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingPageableResponse.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingPageableResponse.java
@@ -9,14 +9,14 @@ public record MatchingPageableResponse(
         int pageNumber,
         int pageSize,
         int numberOfElements,
-        boolean hasNext
+        boolean isLast
 ) {
     public static MatchingPageableResponse of(Slice<?> Slice) {
         return MatchingPageableResponse.builder()
                 .pageNumber(Slice.getNumber())
                 .pageSize(Slice.getSize())
                 .numberOfElements(Slice.getNumberOfElements())
-                .hasNext(Slice.hasNext())
+                .isLast(Slice.isLast())
                 .build();
     }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingRoomListResponse.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingRoomListResponse.java
@@ -2,17 +2,17 @@ package com.gachtaxi.domain.matching.common.dto.response;
 
 import java.util.List;
 import lombok.Builder;
-import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 
 @Builder
 public record MatchingRoomListResponse(
         List<MatchingRoomResponse> rooms,
         MatchingPageableResponse pageable
 ) {
-    public static MatchingRoomListResponse of(Page<MatchingRoomResponse> page) {
+    public static MatchingRoomListResponse of(Slice<MatchingRoomResponse> Slice) {
         return MatchingRoomListResponse.builder()
-                .rooms(page.getContent())
-                .pageable(MatchingPageableResponse.of(page))
+                .rooms(Slice.getContent())
+                .pageable(MatchingPageableResponse.of(Slice))
                 .build();
     }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingRoomResponse.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingRoomResponse.java
@@ -12,8 +12,7 @@ public record MatchingRoomResponse(
         LocalDateTime departureTime,
         int maxCapacity,
         int currentMembers,
-        List<String> tags,
-        Long chattingRoomId
+        List<String> tags
 ) {
     public static MatchingRoomResponse from(MatchingRoom matchingRoom) {
         return new MatchingRoomResponse(
@@ -24,8 +23,7 @@ public record MatchingRoomResponse(
                 matchingRoom.getDepartureTime(),
                 matchingRoom.getCapacity(),
                 matchingRoom.getCurrentMemberCount(),
-                matchingRoom.getTags(),
-                matchingRoom.getChattingRoomId()
+                matchingRoom.getTags()
         );
     }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingRoomResponse.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingRoomResponse.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 public record MatchingRoomResponse(
         Long roomId,
+        Long chattingRoomId,
         String description,
         String departure,
         String destination,
@@ -17,6 +18,7 @@ public record MatchingRoomResponse(
     public static MatchingRoomResponse from(MatchingRoom matchingRoom) {
         return new MatchingRoomResponse(
                 matchingRoom.getId(),
+                matchingRoom.getChattingRoomId(),
                 matchingRoom.getDescription(),
                 matchingRoom.getDeparture(),
                 matchingRoom.getDestination(),

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingRoomResponse.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingRoomResponse.java
@@ -12,7 +12,8 @@ public record MatchingRoomResponse(
         LocalDateTime departureTime,
         int maxCapacity,
         int currentMembers,
-        List<String> tags
+        List<String> tags,
+        Long chattingRoomId
 ) {
     public static MatchingRoomResponse from(MatchingRoom matchingRoom) {
         return new MatchingRoomResponse(
@@ -23,7 +24,8 @@ public record MatchingRoomResponse(
                 matchingRoom.getDepartureTime(),
                 matchingRoom.getCapacity(),
                 matchingRoom.getCurrentMemberCount(),
-                matchingRoom.getTags()
+                matchingRoom.getTags(),
+                matchingRoom.getChattingRoomId()
         );
     }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
@@ -122,7 +122,7 @@ public class MatchingRoom extends BaseEntity {
         .build();
   }
 
-  public static MatchingRoom manualOf(Members roomMaster, String departure, String destination, String description, int maxCapacity, int totalCharge, LocalDateTime departureTime) {
+  public static MatchingRoom manualOf(Members roomMaster, String departure, String destination, String description, int maxCapacity, int totalCharge, LocalDateTime departureTime, Long chattingRoomId) {
     return MatchingRoom.builder()
             .capacity(4)
             .roomMaster(roomMaster)
@@ -131,6 +131,7 @@ public class MatchingRoom extends BaseEntity {
             .destination(destination)
             .totalCharge(totalCharge)
             .departureTime(departureTime)
+            .chattingRoomId(chattingRoomId)
             .matchingRoomType(MatchingRoomType.MANUAL)
             .matchingRoomStatus(MatchingRoomStatus.ACTIVE)
             .build();

--- a/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
@@ -76,6 +76,10 @@ public class MatchingRoom extends BaseEntity {
   @Getter
   private String destination;
 
+  @Column(name = "chatting_room_id")
+  @Getter
+  private Long chattingRoomId;
+
   @Enumerated(EnumType.STRING)
   private MatchingRoomStatus matchingRoomStatus;
 
@@ -153,5 +157,9 @@ public class MatchingRoom extends BaseEntity {
     return this.matchingRoomTagInfo.stream()
             .map(tagInfo -> tagInfo.getTags().name())
             .toList();
+  }
+
+  public void setChattingRoomId(Long chattingRoomId) {
+    this.chattingRoomId = chattingRoomId;
   }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
@@ -158,8 +158,4 @@ public class MatchingRoom extends BaseEntity {
             .map(tagInfo -> tagInfo.getTags().name())
             .toList();
   }
-
-  public void setChattingRoomId(Long chattingRoomId) {
-    this.chattingRoomId = chattingRoomId;
-  }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -1,5 +1,7 @@
 package com.gachtaxi.domain.matching.common.service;
 
+import com.gachtaxi.domain.chat.entity.ChattingRoom;
+import com.gachtaxi.domain.chat.service.ChattingRoomService;
 import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingRequest;
 import com.gachtaxi.domain.matching.common.dto.response.MatchingRoomResponse;
 import com.gachtaxi.domain.matching.common.entity.MatchingRoom;
@@ -43,6 +45,7 @@ public class ManualMatchingService {
     private final MatchingRoomService matchingRoomService;
     private final MatchingInvitationService matchingInvitationService;
     private final BlacklistService blacklistService;
+    private final ChattingRoomService chattingRoomService;
     private final MatchingRoomRepository matchingRoomRepository;
     private final MemberMatchingRoomChargingInfoRepository memberMatchingRoomChargingInfoRepository;
 
@@ -70,6 +73,10 @@ public class ManualMatchingService {
                 request.getTotalCharge(),
                 request.departureTime()
         );
+
+        ChattingRoom chattingRoom = chattingRoomService.create(roomMaster);
+
+        matchingRoom.setChattingRoomId(chattingRoom.getId());
 
         MatchingRoom savedMatchingRoom = matchingRoomRepository.save(matchingRoom);
 

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -1,6 +1,7 @@
 package com.gachtaxi.domain.matching.common.service;
 
 import com.gachtaxi.domain.chat.entity.ChattingRoom;
+import com.gachtaxi.domain.chat.service.ChattingParticipantService;
 import com.gachtaxi.domain.chat.service.ChattingRoomService;
 import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingRequest;
 import com.gachtaxi.domain.matching.common.dto.response.MatchingRoomResponse;
@@ -46,6 +47,7 @@ public class ManualMatchingService {
     private final MatchingInvitationService matchingInvitationService;
     private final BlacklistService blacklistService;
     private final ChattingRoomService chattingRoomService;
+    private final ChattingParticipantService chattingParticipantService;
     private final MatchingRoomRepository matchingRoomRepository;
     private final MemberMatchingRoomChargingInfoRepository memberMatchingRoomChargingInfoRepository;
 
@@ -140,6 +142,8 @@ public class ManualMatchingService {
             matchingRoom.completeMatchingRoom();
             this.matchingRoomRepository.save(matchingRoom);
         }
+
+        chattingParticipantService.joinChattingRoom(user, matchingRoom.getChattingRoomId());
     }
     /*
       todo 수동 매칭 → 자동 매칭 전환 : 추후 고도화시, 10분전에 유저에게 알림을 주고 자동 매칭으로 전환

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -19,6 +19,8 @@ import com.gachtaxi.domain.matching.common.exception.NotActiveMatchingRoomExcept
 import com.gachtaxi.domain.matching.common.repository.MatchingRoomRepository;
 import com.gachtaxi.domain.matching.common.repository.MemberMatchingRoomChargingInfoRepository;
 import com.gachtaxi.domain.members.entity.Members;
+import com.gachtaxi.domain.members.exception.BlacklistedUserCannotJoinException;
+import com.gachtaxi.domain.members.service.BlacklistService;
 import com.gachtaxi.domain.members.service.MemberService;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
@@ -40,6 +42,7 @@ public class ManualMatchingService {
     private final MemberService memberService;
     private final MatchingRoomService matchingRoomService;
     private final MatchingInvitationService matchingInvitationService;
+    private final BlacklistService blacklistService;
     private final MatchingRoomRepository matchingRoomRepository;
     private final MemberMatchingRoomChargingInfoRepository memberMatchingRoomChargingInfoRepository;
 
@@ -98,6 +101,11 @@ public class ManualMatchingService {
 
         if (this.memberMatchingRoomChargingInfoRepository.existsByMembersAndMatchingRoom(user, matchingRoom)) {
             throw new MemberAlreadyJoinedException();
+        }
+
+        boolean isBlacklisted = blacklistService.isUserBlacklistedInRoom(user, matchingRoom);
+        if (isBlacklisted) {
+            throw new BlacklistedUserCannotJoinException();
         }
 
         Optional<MemberMatchingRoomChargingInfo> joinedInPast = this.memberMatchingRoomChargingInfoRepository

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -1,5 +1,7 @@
 package com.gachtaxi.domain.matching.common.service;
 
+import com.gachtaxi.domain.chat.entity.ChattingRoom;
+import com.gachtaxi.domain.chat.repository.ChattingRoomRepository;
 import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingRequest;
 import com.gachtaxi.domain.matching.common.dto.response.MatchingRoomResponse;
 import com.gachtaxi.domain.matching.common.entity.MatchingRoom;
@@ -45,6 +47,7 @@ public class ManualMatchingService {
     private final BlacklistService blacklistService;
     private final MatchingRoomRepository matchingRoomRepository;
     private final MemberMatchingRoomChargingInfoRepository memberMatchingRoomChargingInfoRepository;
+    private final ChattingRoomRepository chattingRoomRepository;
 
     /*
       수동 매칭 방 생성
@@ -61,6 +64,10 @@ public class ManualMatchingService {
             throw new NotEqualStartAndDestinationException();
         }
 
+        ChattingRoom chattingRoom = ChattingRoom.builder()
+                .build();
+        chattingRoomRepository.save(chattingRoom);
+
         MatchingRoom matchingRoom = MatchingRoom.manualOf(
                 roomMaster,
                 request.getDeparture(),
@@ -68,7 +75,8 @@ public class ManualMatchingService {
                 request.description(),
                 4,
                 request.getTotalCharge(),
-                request.departureTime()
+                request.departureTime(),
+                chattingRoom.getId()
         );
 
         MatchingRoom savedMatchingRoom = matchingRoomRepository.save(matchingRoom);

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -1,8 +1,5 @@
 package com.gachtaxi.domain.matching.common.service;
 
-import com.gachtaxi.domain.chat.entity.ChattingRoom;
-import com.gachtaxi.domain.chat.service.ChattingParticipantService;
-import com.gachtaxi.domain.chat.service.ChattingRoomService;
 import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingRequest;
 import com.gachtaxi.domain.matching.common.dto.response.MatchingRoomResponse;
 import com.gachtaxi.domain.matching.common.entity.MatchingRoom;
@@ -46,8 +43,6 @@ public class ManualMatchingService {
     private final MatchingRoomService matchingRoomService;
     private final MatchingInvitationService matchingInvitationService;
     private final BlacklistService blacklistService;
-    private final ChattingRoomService chattingRoomService;
-    private final ChattingParticipantService chattingParticipantService;
     private final MatchingRoomRepository matchingRoomRepository;
     private final MemberMatchingRoomChargingInfoRepository memberMatchingRoomChargingInfoRepository;
 
@@ -75,10 +70,6 @@ public class ManualMatchingService {
                 request.getTotalCharge(),
                 request.departureTime()
         );
-
-        ChattingRoom chattingRoom = chattingRoomService.create(roomMaster);
-
-        matchingRoom.setChattingRoomId(chattingRoom.getId());
 
         MatchingRoom savedMatchingRoom = matchingRoomRepository.save(matchingRoom);
 
@@ -142,8 +133,6 @@ public class ManualMatchingService {
             matchingRoom.completeMatchingRoom();
             this.matchingRoomRepository.save(matchingRoom);
         }
-
-        chattingParticipantService.joinChattingRoom(user, matchingRoom.getChattingRoomId());
     }
     /*
       todo 수동 매칭 → 자동 매칭 전환 : 추후 고도화시, 10분전에 유저에게 알림을 주고 자동 매칭으로 전환

--- a/src/main/java/com/gachtaxi/domain/members/exception/BlacklistedUserCannotJoinException.java
+++ b/src/main/java/com/gachtaxi/domain/members/exception/BlacklistedUserCannotJoinException.java
@@ -1,0 +1,12 @@
+package com.gachtaxi.domain.members.exception;
+
+import static com.gachtaxi.domain.members.exception.ErrorMessage.BLACKLISTED_USER_CANNOT_JOIN;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+
+import com.gachtaxi.global.common.exception.BaseException;
+
+public class BlacklistedUserCannotJoinException extends BaseException {
+    public BlacklistedUserCannotJoinException() {
+        super(FORBIDDEN, BLACKLISTED_USER_CANNOT_JOIN.getMessage());
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/members/exception/ErrorMessage.java
+++ b/src/main/java/com/gachtaxi/domain/members/exception/ErrorMessage.java
@@ -6,15 +6,18 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ErrorMessage {
-
+    // Member
     DUPLICATED_NICKNAME("중복되는 닉네임입니다."),
     DUPLICATED_STUDENT_NUMBER("이미 가입된 학번입니다."),
     MEMBER_NOT_FOUND("회원을 찾을 수 없습니다."),
     DUPLICATED_EMAIL("이미 가입된 이메일이에요!"),
     EMAIL_FROM_INVALID("가천대학교 이메일이 아니에요!"),
+
+    // Blacklist
     BLACKLIST_ALREADY_EXISTS("이미 등록된 블랙리스트입니다."),
     BLACKLIST_NOT_FOUND("블랙리스트를 찾을 수 없습니다."),
-    BLACKLIST_REQUESTER_EQUALS_RECEIVER("본인을 블랙리스트에 추가할 수 없습니다.");
+    BLACKLIST_REQUESTER_EQUALS_RECEIVER("본인을 블랙리스트에 추가할 수 없습니다."),
+    BLACKLISTED_USER_CANNOT_JOIN("블랙리스트로 등록된 사용자의 방은 입장할 수 없습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/gachtaxi/domain/members/service/BlacklistService.java
+++ b/src/main/java/com/gachtaxi/domain/members/service/BlacklistService.java
@@ -11,7 +11,6 @@ import com.gachtaxi.domain.members.exception.BlacklistRequesterEqualsReceiverExc
 import com.gachtaxi.domain.members.repository.BlacklistsRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -77,5 +76,10 @@ public class BlacklistService {
     if (requester.equals(receiver)) {
       throw new BlacklistRequesterEqualsReceiverException();
     }
+  }
+
+  public boolean isUserBlacklistedInRoom(Members requester, MatchingRoom matchingRoom) {
+    return matchingRoom.getMemberMatchingRoomChargingInfo().stream()
+            .anyMatch(info -> this.blacklistsRepository.existsByRequesterAndReceiver(requester, info.getMembers()));
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #78 
Close #

미완성 PR입니다, 일어나서 채팅관련 테스트까지 완료하고 리팩토링 해보겠습니다

## 🚀 작업 내용

- [x] 수동매칭시 블랙리스트 관리 및 매칭시 블랙리스트 제외 로직
수동매칭 참여시 블랙리스트로 등록된 참여자의 예외처리를 해주는 로직을 구현했습니다 
구현하면서 생각난 내용인데 추후 리팩토링시 유저한테 블랙리스트로 지정된 어떤 사람인지에 대한 정보(이름, 닉네임 등)를 반환해주면서, 정말 입장하시겠습니까? 등의 모달을 띄워줘서 예, 아니오 의 내용을 받으면 유저 경험측면에서 선택지가 넓어져서 더 좋을거같다는 생각이 들었습니다

- [x] MatchingRoom 생성시, 채팅방 함께 생성 후 참가
MatchingRoom 생성시 채팅방 함께 생성, 생성된 MatchingRoom이 1:1로 ChattingRoomId를 가져서 
해당 유저(방장) 채팅방 참가 처리하였습니다, 그리고 매칭방 엔티티에  chattingRoomId 필드를 가지도록 추가하였습니다

- [x] MatchingRoom 참여시, 참가하는 매칭방에 해당하는 채팅방도 함께 참가
- [x]  수동 매칭방 조회, 나의 매칭(수동) 조회시 채팅방 ID 함께 반환

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/adba90bb-48a5-4483-a056-f92c5a753ef4)
올바르게 예외처리 되는거 테스트까지 완료했습니다

아래는 예상 플로우입니다

![image](https://github.com/user-attachments/assets/519e4188-f581-422f-879b-a6684f864e21)
유저가 수동매칭을 생성시 해당하는 매칭방과 함께 채팅방도 생성되도록 했습니다

<img width="964" alt="image" src="https://github.com/user-attachments/assets/38751c16-7a06-48a4-ae39-3cef2b191779" />
매칭방이 생성되게 되면, 해당 매칭방에 맞는 채팅방의 ID를 함께 DB에 저장합니다

<img width="631" alt="image" src="https://github.com/user-attachments/assets/78826ea3-0241-414f-a604-57c2afa45e54" />

채팅방 DB에 정상적으로 들어가는 것도 확인했습니다

---

![image](https://github.com/user-attachments/assets/4dafe60b-ef8d-43c7-8141-dea8ffc2843f)
유저가 수동매칭방 리스트 조회시 채팅방도 함께 확인할 수 있고,

<img width="689" alt="image" src="https://github.com/user-attachments/assets/3b7d417a-5acc-480b-9184-becdaeb7241d" />
내 채팅방 리스트 조회시에도 반환되는 채팅방 ID까지 확인할 수 있도록하였습니다

## 📢 리뷰 요구사항
