### PR TITLE
Feat #80 채팅 프로필 수정

### DIFF
--- a/src/main/java/com/gachtaxi/domain/members/service/MemberService.java
+++ b/src/main/java/com/gachtaxi/domain/members/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.gachtaxi.domain.members.service;
 
+import com.gachtaxi.domain.chat.repository.ChattingMessageMongoRepository;
 import com.gachtaxi.domain.members.dto.request.*;
 import com.gachtaxi.domain.members.dto.response.MemberResponseDto;
 import com.gachtaxi.domain.members.entity.Members;
@@ -20,6 +21,7 @@ import static com.gachtaxi.domain.members.entity.enums.UserStatus.ACTIVE;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final ChattingMessageMongoRepository chattingMessageMongoRepository;
 
     @Transactional
     public InactiveMemberDto saveTmpKakaoMember(Long kakaoId){
@@ -37,6 +39,8 @@ public class MemberService {
     public MemberResponseDto updateMemberInfo(Long currentId, MemberInfoRequestDto dto){
         Members member = findById(currentId);
         member.updateMemberInfo(dto);
+
+        chattingMessageMongoRepository.updateMemberInfo(member);
 
         return MemberResponseDto.from(member);
     }

--- a/src/main/java/com/gachtaxi/global/config/SesClientConfig.java
+++ b/src/main/java/com/gachtaxi/global/config/SesClientConfig.java
@@ -10,7 +10,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ses.SesClient;
 
 @Configuration
-public class SesClinetConfig {
+public class SesClientConfig {
 
     @Value("${aws.ses.accessKey}")
     private String accessKey;


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #77 
Close #77 


## 🚀 작업 내용
- 사용자 프로필 수정 시 채팅 메시지에 저장된 프로필 사진과 닉네임을 함께 수정했습니다.
- 업데이트 속도가 느리면 비동기로 처리하려고 하였으나, 200건의 데이터를 업데이트하는데 0.05초 정도로 매우 빠른 속도를 보였습니다. 
- 비동기로 처리함에 큰 메리트가 없다고 생각해 빠른 구현을 우선시 하였습니다. 실제 운영시 피드백이 발생하면 그 때 비동기로 수정하는 방안을 검토해보면 좋을 것 같습니다

## 📸 스크린샷


## 📢 리뷰 요구사항
- 채팅시 사용자의 이미지는 Redis, 닉네임은 웹소켓 세션에 저장됩니다. 사용자가 채팅과 프로필 수정을 동시에 진행하면 웹소켓을 재연결할 때 까지 데이터의 불일치가 나타나지만, 그런 케이스가 적을 뿐더러 어플에서는 불가능하다고 생각했습니다. 
- 기기 2개로 하나는 채팅, 하나는 프로필 수정을 해야 발생할 수 있는 예외 케이스인데 잡아줘야할지 고민입니다.
