### PR TITLE
refactor: 수동매칭 등록 시 시간 String으로 받아 파싱하도록 수정

### DIFF
--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingRequest.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingRequest.java
@@ -19,7 +19,7 @@ public record ManualMatchingRequest(
         String destinationName,
 
         @NotNull
-        LocalDateTime departureTime,
+        String departureTime,
 
         @Schema(description = "예상 요금")
         @Min(value = 0)

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -26,6 +26,7 @@ import com.gachtaxi.domain.members.service.BlacklistService;
 import com.gachtaxi.domain.members.service.MemberService;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -68,6 +69,9 @@ public class ManualMatchingService {
                 .build();
         chattingRoomRepository.save(chattingRoom);
 
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        LocalDateTime departureTime = LocalDateTime.parse(request.getDeparture(), formatter);
+
         MatchingRoom matchingRoom = MatchingRoom.manualOf(
                 roomMaster,
                 request.getDeparture(),
@@ -75,7 +79,7 @@ public class ManualMatchingService {
                 request.description(),
                 4,
                 request.getTotalCharge(),
-                request.departureTime(),
+                departureTime,
                 chattingRoom.getId()
         );
 


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #88
Close #88


## 🚀 작업 내용
> PR에서 작업한 내용을 설명
- 수동 매칭 시 출발 시간 String으로 받아서 파싱하도록 수정

## 📸 스크린샷


## 📢 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
