### PR TITLE
Feat #95 회원탈퇴 API 구현

### DIFF
--- a/src/main/java/com/gachtaxi/domain/members/controller/MemberController.java
+++ b/src/main/java/com/gachtaxi/domain/members/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.gachtaxi.domain.members.controller;
 import com.gachtaxi.domain.members.dto.request.FcmTokenRequest;
 import com.gachtaxi.domain.members.dto.request.MemberInfoRequestDto;
 import com.gachtaxi.domain.members.dto.response.MemberResponseDto;
+import com.gachtaxi.domain.members.service.MemberDeleteService;
 import com.gachtaxi.domain.members.service.MemberService;
 import com.gachtaxi.global.auth.jwt.annotation.CurrentMemberId;
 import com.gachtaxi.global.common.response.ApiResponse;
@@ -22,6 +23,7 @@ import static org.springframework.http.HttpStatus.OK;
 public class MemberController {
 
     private final MemberService memberService;
+    private final MemberDeleteService memberDeleteService;
 
     @PatchMapping("/firebase")
     @Operation(summary = "fcm 토큰을 저장하기 위한 API입니다. 매 로그인 혹은 토큰 리프레시가 발생할 때 저장해주세요")
@@ -45,5 +47,13 @@ public class MemberController {
     ) {
         MemberResponseDto response = memberService.updateMemberInfo(currentId, dto);
         return ApiResponse.response(OK, MEMBER_INFO_UPDATE.getMessage(), response);
+    }
+
+    @DeleteMapping
+    @Operation(summary = "회원 탈퇴 API입니다. 관련 정보가 모두 삭제됩니다.")
+    public ApiResponse<Void> delete(@CurrentMemberId Long currentId) {
+        memberDeleteService.softDelete(currentId);
+
+        return ApiResponse.response(OK, MEMBER_DELETE_SUCCESS.getMessage());
     }
 }

--- a/src/main/java/com/gachtaxi/domain/members/controller/ResponseMessage.java
+++ b/src/main/java/com/gachtaxi/domain/members/controller/ResponseMessage.java
@@ -11,6 +11,7 @@ public enum ResponseMessage {
     MEMBER_INFO_UPDATE("유저 정보를 성공적으로 수정했습니다!"),
     MEMBER_INFO_RESPONSE("유저 정보를 반환합니다."),
     FCM_TOKEN_UPDATE_SUCCESS("FCM 토큰 업데이트에 성공했습니다."),
+    MEMBER_DELETE_SUCCESS("회원 탈퇴에 성공했습니다."),
 
     // AuthController
     ALREADY_SIGN_UP("이미 가입된 이메일 입니다!"),

--- a/src/main/java/com/gachtaxi/domain/members/entity/Members.java
+++ b/src/main/java/com/gachtaxi/domain/members/entity/Members.java
@@ -152,6 +152,10 @@ public class Members extends BaseEntity {
         return this.equals(matchingRoom.getRoomMaster());
     }
 
+    public void delete() {
+        this.status = UserStatus.DELETED;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/src/main/java/com/gachtaxi/domain/members/entity/enums/UserStatus.java
+++ b/src/main/java/com/gachtaxi/domain/members/entity/enums/UserStatus.java
@@ -1,5 +1,5 @@
 package com.gachtaxi.domain.members.entity.enums;
 
 public enum UserStatus {
-    ACTIVE, INACTIVE
+    ACTIVE, INACTIVE, DELETED
 }

--- a/src/main/java/com/gachtaxi/domain/members/repository/MemberRepository.java
+++ b/src/main/java/com/gachtaxi/domain/members/repository/MemberRepository.java
@@ -2,16 +2,18 @@ package com.gachtaxi.domain.members.repository;
 
 import com.gachtaxi.domain.members.entity.Members;
 import com.gachtaxi.domain.members.entity.enums.UserStatus;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Members, Long> {
 
     Optional<Members> findByEmail(String email);
+
+    Optional<Members> findByIdAndStatus(Long id, UserStatus status);
 
     Optional<Members> findByStudentNumber(Long studentNumber);
 

--- a/src/main/java/com/gachtaxi/domain/members/service/MemberDeleteService.java
+++ b/src/main/java/com/gachtaxi/domain/members/service/MemberDeleteService.java
@@ -1,12 +1,8 @@
 package com.gachtaxi.domain.members.service;
 
-import com.gachtaxi.domain.chat.repository.ChattingParticipantRepository;
-import com.gachtaxi.domain.friend.repository.FriendRepository;
-import com.gachtaxi.domain.matching.common.repository.MemberMatchingRoomChargingInfoRepository;
 import com.gachtaxi.domain.members.entity.Members;
 import com.gachtaxi.domain.members.exception.MemberNotFoundException;
 import com.gachtaxi.domain.members.repository.MemberRepository;
-import com.gachtaxi.domain.notification.repository.NotificationRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,30 +12,10 @@ import org.springframework.stereotype.Service;
 public class MemberDeleteService {
 
     private final MemberRepository memberRepository;
-    private final FriendRepository friendRepository;
-    private final ChattingParticipantRepository chattingParticipantRepository;
-    private final MemberMatchingRoomChargingInfoRepository memberMatchingRoomChargingInfoRepository;
-    private final NotificationRepository notificationRepository;
 
     /*
     todo 채팅 메시지 수정 PR 머지 되면 (알수없음)으로 바꾸고 프사 삭제하기
      */
-
-    // 하드 딜리트
-//    @Transactional
-//    public void delete(Long memberId) {
-//        Members member = memberRepository.findById(memberId)
-//                .orElseThrow(MemberNotFoundException::new);
-//
-//        chattingParticipantRepository.deleteAllByMembers(member);
-//        friendRepository.deleteBySenderOrReceiver(member, member);
-//        memberMatchingRoomChargingInfoRepository.deleteAllByMembers(member);
-//
-//        notificationRepository.deleteByReceiverId(memberId);
-//        memberRepository.deleteById(memberId);
-//    }
-
-    // 소프트 딜리트
     @Transactional
     public void softDelete(Long memberId) {
         Members member = memberRepository.findById(memberId)

--- a/src/main/java/com/gachtaxi/domain/members/service/MemberDeleteService.java
+++ b/src/main/java/com/gachtaxi/domain/members/service/MemberDeleteService.java
@@ -1,0 +1,50 @@
+package com.gachtaxi.domain.members.service;
+
+import com.gachtaxi.domain.chat.repository.ChattingParticipantRepository;
+import com.gachtaxi.domain.friend.repository.FriendRepository;
+import com.gachtaxi.domain.matching.common.repository.MemberMatchingRoomChargingInfoRepository;
+import com.gachtaxi.domain.members.entity.Members;
+import com.gachtaxi.domain.members.exception.MemberNotFoundException;
+import com.gachtaxi.domain.members.repository.MemberRepository;
+import com.gachtaxi.domain.notification.repository.NotificationRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberDeleteService {
+
+    private final MemberRepository memberRepository;
+    private final FriendRepository friendRepository;
+    private final ChattingParticipantRepository chattingParticipantRepository;
+    private final MemberMatchingRoomChargingInfoRepository memberMatchingRoomChargingInfoRepository;
+    private final NotificationRepository notificationRepository;
+
+    /*
+    todo 채팅 메시지 수정 PR 머지 되면 (알수없음)으로 바꾸고 프사 삭제하기
+     */
+
+    // 하드 딜리트
+//    @Transactional
+//    public void delete(Long memberId) {
+//        Members member = memberRepository.findById(memberId)
+//                .orElseThrow(MemberNotFoundException::new);
+//
+//        chattingParticipantRepository.deleteAllByMembers(member);
+//        friendRepository.deleteBySenderOrReceiver(member, member);
+//        memberMatchingRoomChargingInfoRepository.deleteAllByMembers(member);
+//
+//        notificationRepository.deleteByReceiverId(memberId);
+//        memberRepository.deleteById(memberId);
+//    }
+
+    // 소프트 딜리트
+    @Transactional
+    public void softDelete(Long memberId) {
+        Members member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        member.delete();
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/members/service/MemberService.java
+++ b/src/main/java/com/gachtaxi/domain/members/service/MemberService.java
@@ -50,13 +50,13 @@ public class MemberService {
 
     @Transactional
     public void updateMemberEmail(String email, Long userId) {
-        Members members = findById(userId);
+        Members members = findTempUserById(userId);
         members.updateEmail(email);
     }
 
     @Transactional
     public void updateMemberAgreement(MemberAgreementRequestDto dto, Long userId) {
-        Members members = findById(userId);
+        Members members = findTempUserById(userId);
         members.updateAgreement(dto);
     }
 
@@ -65,7 +65,7 @@ public class MemberService {
         checkDuplicatedNickName(dto.nickname());
         checkDuplicatedStudentNumber(dto.studentNumber());
 
-        Members members = findById(userId);
+        Members members = findTempUserById(userId);
         members.updateSupplment(dto);
 
         return MemberResponseDto.from(members);
@@ -88,6 +88,11 @@ public class MemberService {
 
     public Members findById(Long id) {
         return memberRepository.findByIdAndStatus(id, ACTIVE)
+                .orElseThrow(MemberNotFoundException::new);
+    }
+
+    public Members findTempUserById(Long id) {
+        return memberRepository.findById(id)
                 .orElseThrow(MemberNotFoundException::new);
     }
 

--- a/src/main/java/com/gachtaxi/domain/members/service/MemberService.java
+++ b/src/main/java/com/gachtaxi/domain/members/service/MemberService.java
@@ -87,7 +87,7 @@ public class MemberService {
     * */
 
     public Members findById(Long id) {
-        return memberRepository.findById(id)
+        return memberRepository.findByIdAndStatus(id, ACTIVE)
                 .orElseThrow(MemberNotFoundException::new);
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #81 
Close #81


## 🚀 작업 내용
- 회원탈퇴 API를 구현했습니다
- 소프트 딜리트로 구현함에 따라 외부에서 멤버를 조회하는 메서드에 ACTIVE로 조회하고, 임시 유저는 그냥 조회하도록 분리를 했습니다.
- 차후 채팅 메시지 수정, 친구/블랙 리스트 삭제를 위해 의존성을 낮추고자 별도 서비스로 분리했습니다.


## 📸 스크린샷


## 📢 리뷰 요구사항
- 유저 도메인 담당자 분 께서는 문제가 없는지 유심히 봐주시면 감사하겠습니다..
