### PR TITLE
Refactor #97 수동매칭 수락 거절 구현

### DIFF
--- a/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
@@ -8,6 +8,7 @@ import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.JOI
 import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.LEAVE_MANUAL_MATCHING_ROOM_SUCCESS;
 import static org.springframework.http.HttpStatus.OK;
 
+import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingInviteReplyRequest;
 import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingJoinRequest;
 import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingRequest;
 import com.gachtaxi.domain.matching.common.dto.response.MatchingRoomListResponse;
@@ -27,7 +28,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "MANUAL", description = "수동매칭 API")
@@ -53,11 +53,10 @@ public class ManualMatchingController {
         return ApiResponse.response(OK, JOIN_MANUAL_MATCHING_ROOM_SUCCESS.getMessage());
     }
 
-    @Operation(summary = "수동 매칭 초대 수락")
-    @PostMapping("/invite/accept")
-    public ApiResponse<Void> acceptInvitation(@CurrentMemberId Long userId, @RequestParam Long matchingRoomId, @RequestParam String notificationId
-    ) {
-        matchingInvitationService.acceptInvitation(userId, matchingRoomId, notificationId);
+    @Operation(summary = "수동 매칭 초대 수락/거절")
+    @PostMapping("/invite/reply")
+    public ApiResponse<Void> acceptInvitation(@CurrentMemberId Long userId, @Valid @RequestBody ManualMatchingInviteReplyRequest request) {
+        matchingInvitationService.acceptInvitation(userId, request);
         return ApiResponse.response(OK, ACCEPT_MATCHING_INVITE_SUCCESS.getMessage());
     }
 

--- a/src/main/java/com/gachtaxi/domain/matching/common/controller/ResponseMessage.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/controller/ResponseMessage.java
@@ -22,7 +22,7 @@ public enum ResponseMessage {
   CONVERT_TO_AUTO_MATCHING_SUCCESS("자동 매칭으로 전환되었습니다."),
   GET_MANUAL_MATCHING_LIST_SUCCESS("수동 매칭방 조회에 성공했습니다."),
   GET_MY_MATCHING_LIST_SUCCESS("내 매칭방 조회에 성공했습니다."),
-  ACCEPT_MATCHING_INVITE_SUCCESS("매칭방 초대 수락에 성공했습니다");
+  ACCEPT_MATCHING_INVITE_SUCCESS("매칭방 초대를 수락/거절이 완료되었습니다");
 
   private final String message;
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingInviteReplyRequest.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingInviteReplyRequest.java
@@ -1,0 +1,14 @@
+package com.gachtaxi.domain.matching.common.dto.request;
+
+import com.gachtaxi.domain.matching.common.entity.enums.MatchingInviteStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record ManualMatchingInviteReplyRequest(
+        @NotNull
+        Long matchingRoomId,
+        @NotNull
+        String notificationId,
+        @NotNull
+        MatchingInviteStatus status
+        ) {
+}

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingPageableResponse.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingPageableResponse.java
@@ -9,14 +9,14 @@ public record MatchingPageableResponse(
         int pageNumber,
         int pageSize,
         int numberOfElements,
-        boolean isLast
+        boolean last
 ) {
-    public static MatchingPageableResponse of(Slice<?> Slice) {
+    public static MatchingPageableResponse of(Slice<?> slice) {
         return MatchingPageableResponse.builder()
-                .pageNumber(Slice.getNumber())
-                .pageSize(Slice.getSize())
-                .numberOfElements(Slice.getNumberOfElements())
-                .isLast(Slice.isLast())
+                .pageNumber(slice.getNumber())
+                .pageSize(slice.getSize())
+                .numberOfElements(slice.getNumberOfElements())
+                .last(slice.isLast())
                 .build();
     }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingRoomListResponse.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingRoomListResponse.java
@@ -9,10 +9,10 @@ public record MatchingRoomListResponse(
         List<MatchingRoomResponse> rooms,
         MatchingPageableResponse pageable
 ) {
-    public static MatchingRoomListResponse of(Slice<MatchingRoomResponse> Slice) {
+    public static MatchingRoomListResponse of(Slice<MatchingRoomResponse> slice) {
         return MatchingRoomListResponse.builder()
-                .rooms(Slice.getContent())
-                .pageable(MatchingPageableResponse.of(Slice))
+                .rooms(slice.getContent().stream().toList())
+                .pageable(MatchingPageableResponse.of(slice))
                 .build();
     }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/entity/enums/MatchingInviteStatus.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/entity/enums/MatchingInviteStatus.java
@@ -1,0 +1,5 @@
+package com.gachtaxi.domain.matching.common.entity.enums;
+
+public enum MatchingInviteStatus {
+    ACCEPT, REJECT
+}

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/MatchingInvitationService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/MatchingInvitationService.java
@@ -76,7 +76,7 @@ public class MatchingInvitationService {
         }
 
         if (request.status() == MatchingInviteStatus.REJECT) {
-            notificationRepository.save(notification);
+            notificationRepository.delete(notification);
             return;
         }
 


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #90 
Close #


## 🚀 작업 내용
수동매칭 수락 / 거절 로직
서비스단에서 입력받은 DTO를 검증을 통해서 status가  ACCEPT면 친구 추가 로직, 친구 추가 되었다고 반환 
REJECT면 친구 추가 로직 x, 친구 추가 거절 되었다고 케이스 별로 분리해서 알림을 발행하도록 구현

수동매칭 리스트 payload 변수명만 isLast로 설정 (last로 매핑되도록)


## 📸 스크린샷
<img width="677" alt="스크린샷 2025-02-05 오전 12 20 00" src="https://github.com/user-attachments/assets/a8bf7128-cda8-4f1c-b2c2-9e415328c9fa" />

유저가 수동매칭 초대 거절시 매칭방 초대를 수락/거절이 완료되었습니다의 응답이 반환되고

![image](https://github.com/user-attachments/assets/210b1784-41b6-4419-8c24-c154baa76042)

DB에 값이 저장되지 않습니다

![image](https://github.com/user-attachments/assets/dcbf353d-ca47-49a2-9650-017117ae7c75)

만약 유저가 수동매칭 초대를 수락할시

![image](https://github.com/user-attachments/assets/14f02658-8d8b-4ff0-8282-c6a82da3c723)

DB에 올바르게 데이터가 값이 저장되도록 했습니다

## 📢 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
