### PR TITLE
Fix #115 나의 매칭 리스트 쿼리 조건 수정

### DIFF
--- a/src/main/java/com/gachtaxi/domain/matching/common/repository/MatchingRoomRepository.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/repository/MatchingRoomRepository.java
@@ -52,6 +52,7 @@ public interface MatchingRoomRepository extends JpaRepository<MatchingRoom, Long
     @Query("SELECT m.matchingRoom FROM MemberMatchingRoomChargingInfo m " +
             "WHERE m.members = :user " +
             "AND m.matchingRoom.matchingRoomStatus = 'ACTIVE' " +
+            "AND m.paymentStatus != 'LEFT'" +
             "ORDER BY m.matchingRoom.id DESC")
     Page<MatchingRoom> findByMemberInMatchingRoom(@Param("user") Members user, Pageable pageable);
 }


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #114 
Close #


## 🚀 작업 내용

조건을 쿼리문에 "AND m.paymentStatus != 'LEFT'" 를 추가해서 방을 떠난 참가자는 나의 매칭에서 방이 조회 안되도록 수정

## 📸 스크린샷


## 📢 리뷰 요구사항

변경된 쿼리문 테스트까지 완료됐습니다