### PR TITLE
Fix #117 자동 매칭방 탐색시 타입이 수동인 매칭방을 제외하고 탐색

### DIFF
--- a/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
@@ -4,26 +4,14 @@ import com.gachtaxi.domain.chat.entity.ChattingRoom;
 import com.gachtaxi.domain.matching.algorithm.dto.FindRoomResult;
 import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomStatus;
 import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomType;
-import com.gachtaxi.domain.matching.event.dto.kafka_topic.MatchRoomCreatedEvent;
 import com.gachtaxi.domain.matching.common.entity.enums.Tags;
+import com.gachtaxi.domain.matching.event.dto.kafka_topic.MatchRoomCreatedEvent;
 import com.gachtaxi.domain.members.entity.Members;
 import com.gachtaxi.global.common.entity.BaseEntity;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import lombok.*;
+
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Table(name = "matching_room")
@@ -120,6 +108,7 @@ public class MatchingRoom extends BaseEntity {
         .departure(matchRoomCreatedEvent.startName())
         .destination(matchRoomCreatedEvent.destinationName())
         .totalCharge(matchRoomCreatedEvent.expectedTotalCharge())
+        .matchingRoomType(MatchingRoomType.AUTO)
         .matchingRoomStatus(MatchingRoomStatus.ACTIVE)
         .chattingRoomId(chattingRoom.getId())
         .build();

--- a/src/main/java/com/gachtaxi/domain/matching/common/repository/MatchingRoomRepository.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/repository/MatchingRoomRepository.java
@@ -33,7 +33,7 @@ public interface MatchingRoomRepository extends JpaRepository<MatchingRoom, Long
             "WHERE r.departure = :departure " +
             "AND r.destination = :destination " +
             "AND r.matchingRoomStatus = 'ACTIVE'" +
-            "AND r.matchingRoomType != 'MANUAL' ")
+            "AND r.matchingRoomType = 'AUTO' ")
     List<MatchingRoom> findRoomsByDepartureAndDestination(@Param("departure") String departure, @Param("destination") String destination);
 
     @Query("SELECT r " +

--- a/src/main/java/com/gachtaxi/domain/matching/common/repository/MatchingRoomRepository.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/repository/MatchingRoomRepository.java
@@ -4,13 +4,14 @@ import com.gachtaxi.domain.matching.common.entity.MatchingRoom;
 import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomStatus;
 import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomType;
 import com.gachtaxi.domain.members.entity.Members;
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface MatchingRoomRepository extends JpaRepository<MatchingRoom, Long> {
@@ -31,8 +32,10 @@ public interface MatchingRoomRepository extends JpaRepository<MatchingRoom, Long
     @Query("SELECT r FROM MatchingRoom r " +
             "WHERE r.departure = :departure " +
             "AND r.destination = :destination " +
-            "AND r.matchingRoomStatus = 'ACTIVE' ")
+            "AND r.matchingRoomStatus = 'ACTIVE'" +
+            "AND r.matchingRoomType != 'MANUAL' ")
     List<MatchingRoom> findRoomsByDepartureAndDestination(@Param("departure") String departure, @Param("destination") String destination);
+
     @Query("SELECT r " +
             "FROM MatchingRoom r JOIN r.memberMatchingRoomChargingInfo m " +
             "WHERE m.members = :user "+


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #116 
Close #116


## 🚀 작업 내용
- 수동 매칭방이 있는 상태에서 동일한 조건의 자동매칭을 돌렸을 때 수동 매칭방에 매칭이 되는 문제가 있어 이를 수정했습니다.
- 해당 매칭 알고리즘이 임시인 만큼 위도 경도를 추가 검색하는 기존 자동매칭 로직에서는 해당 문제가 없을 것으로 예상합니다.
- 하지만 수동 매칭 또한 일관성 있게, 혹은 사용자가 지도에 찍은 위치를 받아 위도 경도를 함께 저장하도록 확장되는 경우 DB에서 가져올 때 matchingRoomType을 적절하게 필터링해줘야할 듯 합니다.
- 자동 방의 경우 생성될 때 Type이 들어가고 있지 않아 이를 추가했습니다.


## 📸 스크린샷


## 📢 리뷰 요구사항
