### PR TITLE
Fix #119 프로필 수정 시 닉네임 중복 체크 추가

### DIFF
--- a/src/main/java/com/gachtaxi/domain/members/service/MemberService.java
+++ b/src/main/java/com/gachtaxi/domain/members/service/MemberService.java
@@ -38,6 +38,8 @@ public class MemberService {
     @Transactional
     public MemberResponseDto updateMemberInfo(Long currentId, MemberInfoRequestDto dto){
         Members member = findById(currentId);
+        checkDuplicatedNickName(dto.nickName());
+
         member.updateMemberInfo(dto);
 
         chattingMessageMongoRepository.updateMemberInfo(member);

--- a/src/main/java/com/gachtaxi/domain/members/service/MemberService.java
+++ b/src/main/java/com/gachtaxi/domain/members/service/MemberService.java
@@ -38,7 +38,7 @@ public class MemberService {
     @Transactional
     public MemberResponseDto updateMemberInfo(Long currentId, MemberInfoRequestDto dto){
         Members member = findById(currentId);
-        checkDuplicatedNickName(dto.nickName());
+        checkDuplicatedNickName(dto.nickName(), member);
 
         member.updateMemberInfo(dto);
 
@@ -121,6 +121,14 @@ public class MemberService {
     private void checkDuplicatedNickName(String nickName) {
         memberRepository.findByNickname(nickName).ifPresent(m -> {
             throw new DuplicatedNickNameException();
+        });
+    }
+
+    private void checkDuplicatedNickName(String nickName, Members member) {
+        memberRepository.findByNickname(nickName).ifPresent(m -> {
+            if (!m.equals(member)) {
+                throw new DuplicatedNickNameException();
+            }
         });
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #118
Close #118 


## 🚀 작업 내용
- 프로필에서 닉네임 수정 시 중복되는 닉네임을 체크해서 예외를 던지도록 수정했습니다.
- 중복 검사시 만약 내 현재 닉네임을 그대로 한 상태로 변경을 눌렀을 때는 예외를 터트리지 않게 구현했습니다.
- 지금 내 닉네임인데 저장이 안되면 플로우가 이상할 거라 판단했습니다

## 📸 스크린샷
<img width="347" alt="image" src="https://github.com/user-attachments/assets/df37ff32-c86f-42f7-964b-bab92606cc05" />


## 📢 리뷰 요구사항
- 현재 내 닉네임을 요청했을 경우 중복을 보여줄지 그대로 통과시킬지 의견을 말해주시면 좋을 것 같습니당