### PR TITLE
Feat #124 채팅 카프카 이전

### DIFF
--- a/src/main/java/com/gachtaxi/domain/chat/kafka/KafkaChatPublisher.java
+++ b/src/main/java/com/gachtaxi/domain/chat/kafka/KafkaChatPublisher.java
@@ -1,0 +1,24 @@
+package com.gachtaxi.domain.chat.kafka;
+
+import com.gachtaxi.domain.chat.dto.request.ChatMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaChatPublisher {
+
+    private final KafkaTemplate<String, ChatMessage> chatKafkaTemplate;
+
+    @Value("${gachtaxi.kafka.topics.chat-room}")
+    private String topic;
+
+    public void publish(ChatMessage chatMessage) {
+        log.info("📤 Kafka 채팅 메시지 발행: {}", chatMessage);
+        chatKafkaTemplate.send(topic, chatMessage.roomId().toString(), chatMessage);
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/chat/kafka/KafkaChatSubscriber.java
+++ b/src/main/java/com/gachtaxi/domain/chat/kafka/KafkaChatSubscriber.java
@@ -1,0 +1,41 @@
+package com.gachtaxi.domain.chat.kafka;
+
+import com.gachtaxi.domain.chat.dto.request.ChatMessage;
+import com.gachtaxi.domain.chat.exception.CustomMessagingException;
+import com.gachtaxi.domain.chat.exception.CustomSerializationException;
+import com.gachtaxi.domain.chat.exception.RedisSubscribeException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.serializer.SerializationException;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Component;
+
+import static com.gachtaxi.domain.chat.redis.RedisChatSubscriber.CHAT_ROOM_PREFIX;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaChatSubscriber {
+
+    private final SimpMessageSendingOperations simpMessageSendingOperations;
+
+    @KafkaListener(topics = "${gachtaxi.kafka.topics.chat-room}", groupId = "${spring.kafka.consumer.chat-group-id}", containerFactory = "chatMessageListenerFactory")
+    public void consumeChatMessage(@Payload ChatMessage chatMessage, Acknowledgment acknowledgment) {
+        try {
+            log.info("📤 Kafka 채팅 메시지 읽기 성공: {}", chatMessage);
+
+            simpMessageSendingOperations.convertAndSend(CHAT_ROOM_PREFIX + chatMessage.roomId(), chatMessage);
+            acknowledgment.acknowledge();
+        } catch (MessagingException e) {
+            throw new CustomMessagingException(e.getMessage());
+        } catch (SerializationException e) {
+            throw new CustomSerializationException(e.getMessage());
+        } catch (Exception e) {
+            throw new RedisSubscribeException(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/chat/redis/RedisChatSubscriber.java
+++ b/src/main/java/com/gachtaxi/domain/chat/redis/RedisChatSubscriber.java
@@ -5,7 +5,6 @@ import com.gachtaxi.domain.chat.exception.CustomMessagingException;
 import com.gachtaxi.domain.chat.exception.CustomSerializationException;
 import com.gachtaxi.domain.chat.exception.RedisSubscribeException;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -14,12 +13,11 @@ import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Component;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class RedisChatSubscriber implements MessageListener {
 
-    private static final String CHAT_ROOM_PREFIX = "/sub/chat/room/";
+    public static final String CHAT_ROOM_PREFIX = "/sub/chat/room/";
 
     private final RedisTemplate<String, ChatMessage> chatRedisTemplate;
     private final SimpMessageSendingOperations simpMessageSendingOperations;

--- a/src/main/java/com/gachtaxi/domain/chat/service/ChattingParticipantService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChattingParticipantService.java
@@ -7,6 +7,7 @@ import com.gachtaxi.domain.chat.entity.ChattingRoom;
 import com.gachtaxi.domain.chat.entity.enums.MessageType;
 import com.gachtaxi.domain.chat.exception.ChattingParticipantNotFoundException;
 import com.gachtaxi.domain.chat.exception.DuplicateSubscribeException;
+import com.gachtaxi.domain.chat.kafka.KafkaChatPublisher;
 import com.gachtaxi.domain.chat.redis.RedisChatPublisher;
 import com.gachtaxi.domain.chat.repository.ChattingMessageMongoRepository;
 import com.gachtaxi.domain.chat.repository.ChattingParticipantRepository;
@@ -27,6 +28,7 @@ public class ChattingParticipantService {
     private final ChattingMessageMongoRepository chattingMessageMongoRepository;
     private final ChattingRedisService chattingRedisService;
     private final RedisChatPublisher redisChatPublisher;
+    private final KafkaChatPublisher kafkaChatPublisher;
 
     @Value("${chat.topic}")
     public String chatTopic;
@@ -83,6 +85,6 @@ public class ChattingParticipantService {
         ChannelTopic topic = new ChannelTopic(chatTopic + roomId);
         ChatMessage chatMessage = ChatMessage.of(roomId, senderId, senderName, range, MessageType.READ);
 
-        redisChatPublisher.publish(topic, chatMessage);
+        kafkaChatPublisher.publish(chatMessage);
     }
 }

--- a/src/main/java/com/gachtaxi/domain/chat/service/ChattingRoomService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChattingRoomService.java
@@ -9,6 +9,7 @@ import com.gachtaxi.domain.chat.entity.ChattingRoom;
 import com.gachtaxi.domain.chat.entity.enums.ChatStatus;
 import com.gachtaxi.domain.chat.entity.enums.MessageType;
 import com.gachtaxi.domain.chat.exception.ChattingRoomNotFoundException;
+import com.gachtaxi.domain.chat.kafka.KafkaChatPublisher;
 import com.gachtaxi.domain.chat.redis.RedisChatPublisher;
 import com.gachtaxi.domain.chat.repository.ChattingMessageRepository;
 import com.gachtaxi.domain.chat.repository.ChattingRoomRepository;
@@ -37,6 +38,7 @@ public class ChattingRoomService {
     private final ChattingParticipantService chattingParticipantService;
     private final MemberService memberService;
     private final RedisChatPublisher redisChatPublisher;
+    private final KafkaChatPublisher kafkaChatPublisher;
     private final ChattingRedisService chattingRedisService;
 
     @Value("${chat.topic}")
@@ -112,6 +114,6 @@ public class ChattingRoomService {
         ChannelTopic topic = new ChannelTopic(chatTopic + roomId);
         ChatMessage chatMessage = ChatMessage.from(chattingMessage);
 
-        redisChatPublisher.publish(topic, chatMessage);
+        kafkaChatPublisher.publish(chatMessage);
     }
 }

--- a/src/main/java/com/gachtaxi/domain/chat/service/ChattingService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChattingService.java
@@ -9,6 +9,7 @@ import com.gachtaxi.domain.chat.entity.ChattingMessage;
 import com.gachtaxi.domain.chat.entity.ChattingParticipant;
 import com.gachtaxi.domain.chat.entity.ChattingRoom;
 import com.gachtaxi.domain.chat.exception.WebSocketSessionException;
+import com.gachtaxi.domain.chat.kafka.KafkaChatPublisher;
 import com.gachtaxi.domain.chat.redis.RedisChatPublisher;
 import com.gachtaxi.domain.chat.repository.ChattingMessageRepository;
 import com.gachtaxi.domain.members.entity.Members;
@@ -38,6 +39,7 @@ public class ChattingService {
 
     private final ChattingMessageRepository chattingMessageRepository;
     private final RedisChatPublisher redisChatPublisher;
+    private final KafkaChatPublisher kafkaChatPublisher;
     private final ChattingRoomService chattingRoomService;
     private final ChattingParticipantService chattingParticipantService;
     private final MemberService memberService;
@@ -62,7 +64,7 @@ public class ChattingService {
         ChannelTopic topic = new ChannelTopic(chatTopic + roomId);
         ChatMessage chatMessage = ChatMessage.from(chattingMessage);
 
-        redisChatPublisher.publish(topic, chatMessage);
+        kafkaChatPublisher.publish(chatMessage);
         /*
         todo 채팅에 알림이 도입되면 redis에 참여하지 않은 사람 리스트를 가져와서 푸시알림 보내기. 참여하고 있다면 X
          */

--- a/src/main/java/com/gachtaxi/global/config/kafka/DefaultKafkaProducerConfig.java
+++ b/src/main/java/com/gachtaxi/global/config/kafka/DefaultKafkaProducerConfig.java
@@ -1,7 +1,6 @@
 package com.gachtaxi.global.config.kafka;
 
-import java.util.HashMap;
-import java.util.Map;
+import com.gachtaxi.domain.chat.dto.request.ChatMessage;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
@@ -12,6 +11,9 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Configuration
 public class DefaultKafkaProducerConfig {
@@ -38,5 +40,24 @@ public class DefaultKafkaProducerConfig {
   @Bean
   public KafkaTemplate<String, Object> kafkaTemplate() {
     return new KafkaTemplate<>(producerFactory());
+  }
+
+  @Bean
+  public ProducerFactory<String, ChatMessage> chatProducerFactory() {
+    Map<String, Object> configs = new HashMap<>();
+    configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    configs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    configs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+
+    configs.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+    configs.put(ProducerConfig.ACKS_CONFIG, "all");
+    configs.put(ProducerConfig.RETRIES_CONFIG, 3);
+
+    return new DefaultKafkaProducerFactory<>(configs);
+  }
+
+  @Bean
+  public KafkaTemplate<String, ChatMessage> chatKafkaTemplate() {
+    return new KafkaTemplate<>(chatProducerFactory());
   }
 }

--- a/src/main/java/com/gachtaxi/global/config/kafka/KafkaBeanRegistrar.java
+++ b/src/main/java/com/gachtaxi/global/config/kafka/KafkaBeanRegistrar.java
@@ -1,13 +1,6 @@
 package com.gachtaxi.global.config.kafka;
 
-import static com.gachtaxi.global.auth.jwt.util.kafka.KafkaBeanSuffix.KAFKA_TEMPLATE_SUFFIX;
-import static com.gachtaxi.global.auth.jwt.util.kafka.KafkaBeanSuffix.NEW_TOPIC_SUFFIX;
-import static com.gachtaxi.global.auth.jwt.util.kafka.KafkaBeanSuffix.PRODUCER_FACTORY_SUFFIX;
-
 import com.gachtaxi.global.auth.jwt.util.KafkaBeanUtils;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -24,6 +17,12 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.gachtaxi.global.auth.jwt.util.kafka.KafkaBeanSuffix.*;
 
 @Component
 public class KafkaBeanRegistrar implements BeanDefinitionRegistryPostProcessor, EnvironmentAware {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -26,6 +26,7 @@ spring:
         max.in.flight.requests.per.connection: ${KAFKA_PRODUCER_MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION}
     consumer:
       group-id: ${KAFKA_CONSUMER_GROUP_ID}
+      chat-group-id: ${KAFKA_CHAT_CONSUMER_GROUP_ID}
       auto-offset-reset: ${KAFKA_CONSUMER_AUTO_OFFSET_RESET}
       enable-auto-commit: ${KAFKA_CONSUMER_ENABLE_AUTO_COMMIT}
     admin:
@@ -69,6 +70,7 @@ gachtaxi:
       match-member-cancelled: ${KAFKA_TOPIC_MATCH_MEMBER_CANCELLED}
       match-room-cancelled: ${KAFKA_TOPIC_MATCH_ROOM_CANCELLED}
       match-room-completed: ${KAFKA_TOPIC_MATCH_ROOM_COMPLETED}
+      chat-room: ${KAFKA_TOPIC_CHAT_ROOM}
     partition-count: ${KAFKA_PARTITION_COUNT}
     replication-factor: ${KAFKA_REPLICATION_FACTOR}
   matching:


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #74 
Close #74 


## 🚀 작업 내용
- 이전 redis로 메시지 발행을 하던 것을 카프카로 이전했습니다.
- 이전한 이유는 무중단 배포가 돌아갈 때 발행된 메시지의 유실을 막기 위해 이전하였습니다.
- 카프카에 chat-group을 추가하였고, 채팅을 위한 topic을 추가했습니다.
- ChatMessage만 다루는 Producer, Consumer 설정을 추가했습니다. ACK는 All로 설정해 메시지 유실을 방지했고, 재시도 횟수는 3회로 설정했습니다.
- KafkaChatSubscriber에서 메시지를 받을 시 ack를 읽음 처리해 메시지 중복 처리를 막았습니다.

- jmeter를 이용한 부하테스트시 무중단 테스트까지는 진행하지 못했지만, 서버가 꺼진 상태에서 카프카에 메시지가 전송된 경우 서버가 다시 켜졌을 때 처리되지 않은 메시지부터 Consumer에게 정상적으로 발행되는 것을 테스트 완료했습니다
## 📸 스크린샷
- 자체 채팅 테스트 진행했습니다

## 📢 리뷰 요구사항
