### PR TITLE
Refactor #126 수동매칭 요청반환 데이터 변경

### DIFF
--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingRequest.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingRequest.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import java.time.LocalDateTime;
 import java.util.List;
 
 public record ManualMatchingRequest(
@@ -20,6 +19,9 @@ public record ManualMatchingRequest(
 
         @NotNull
         String departureTime,
+
+        @NotNull
+        String departureDate,
 
         @Schema(description = "예상 요금")
         @Min(value = 4000)

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingRequest.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/request/ManualMatchingRequest.java
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record ManualMatchingRequest(
@@ -12,20 +14,20 @@ public record ManualMatchingRequest(
         String description,
 
         @NotBlank
-        String startName,
+        String departure,
 
         @NotBlank
-        String destinationName,
+        String destination,
 
         @NotNull
-        String departureTime,
+        LocalDateTime departureTime,
 
         @NotNull
-        String departureDate,
+        LocalDate departureDate,
 
         @Schema(description = "예상 요금")
         @Min(value = 4000)
-        int expectedTotalCharge,
+        int totalCharge,
 
         @Schema(description = "매칭 태그")
         List<String> criteria,
@@ -41,17 +43,5 @@ public record ManualMatchingRequest(
 
     public List<Long> getFriendsId() {
         return members;
-    }
-
-    public int getTotalCharge() {
-        return expectedTotalCharge;
-    }
-
-    public String getDeparture() {
-        return startName;
-    }
-
-    public String getDestination() {
-        return destinationName;
     }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingRoomResponse.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingRoomResponse.java
@@ -10,6 +10,7 @@ public record MatchingRoomResponse(
         String departure,
         String destination,
         String departureTime,
+        String departureDate,
         int maxCapacity,
         int currentMembers,
         List<String> tags
@@ -22,6 +23,7 @@ public record MatchingRoomResponse(
                 matchingRoom.getDeparture(),
                 matchingRoom.getDestination(),
                 matchingRoom.getDepartureTime(),
+                matchingRoom.getDepartureDate(),
                 matchingRoom.getCapacity(),
                 matchingRoom.getCurrentMemberCount(),
                 matchingRoom.getTags()

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingRoomResponse.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingRoomResponse.java
@@ -6,6 +6,8 @@ import java.util.List;
 public record MatchingRoomResponse(
         Long roomId,
         Long chattingRoomId,
+        String nickname,
+        String profilePicture,
         String description,
         String departure,
         String destination,
@@ -19,6 +21,8 @@ public record MatchingRoomResponse(
         return new MatchingRoomResponse(
                 matchingRoom.getId(),
                 matchingRoom.getChattingRoomId(),
+                matchingRoom.getRoomMaster().getNickname(),
+                matchingRoom.getRoomMaster().getProfilePicture(),
                 matchingRoom.getDescription(),
                 matchingRoom.getDeparture(),
                 matchingRoom.getDestination(),

--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingRoomResponse.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingRoomResponse.java
@@ -1,6 +1,8 @@
 package com.gachtaxi.domain.matching.common.dto.response;
 
 import com.gachtaxi.domain.matching.common.entity.MatchingRoom;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record MatchingRoomResponse(
@@ -11,8 +13,8 @@ public record MatchingRoomResponse(
         String description,
         String departure,
         String destination,
-        String departureTime,
-        String departureDate,
+        LocalDateTime departureTime,
+        LocalDate departureDate,
         int maxCapacity,
         int currentMembers,
         List<String> tags

--- a/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
@@ -56,6 +56,10 @@ public class MatchingRoom extends BaseEntity {
   @Getter
   private String departureTime;
 
+  @Column(name = "departure_date")
+  @Getter
+  private String departureDate;
+
   @Column(name = "departure")
   @Getter
   private String departure;
@@ -114,7 +118,7 @@ public class MatchingRoom extends BaseEntity {
         .build();
   }
 
-  public static MatchingRoom manualOf(Members roomMaster, String departure, String destination, String description, int maxCapacity, int totalCharge, String departureTime, Long chattingRoomId) {
+  public static MatchingRoom manualOf(Members roomMaster, String departure, String destination, String description, int maxCapacity, int totalCharge, String departureTime, String departureDate,Long chattingRoomId) {
     return MatchingRoom.builder()
             .capacity(4)
             .roomMaster(roomMaster)
@@ -123,6 +127,7 @@ public class MatchingRoom extends BaseEntity {
             .destination(destination)
             .totalCharge(totalCharge)
             .departureTime(departureTime)
+            .departureDate(departureDate)
             .chattingRoomId(chattingRoomId)
             .matchingRoomType(MatchingRoomType.MANUAL)
             .matchingRoomStatus(MatchingRoomStatus.ACTIVE)

--- a/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/entity/MatchingRoom.java
@@ -9,6 +9,8 @@ import com.gachtaxi.domain.matching.event.dto.kafka_topic.MatchRoomCreatedEvent;
 import com.gachtaxi.domain.members.entity.Members;
 import com.gachtaxi.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.*;
 
 import java.util.List;
@@ -54,11 +56,11 @@ public class MatchingRoom extends BaseEntity {
 
   @Column(name = "departure_time")
   @Getter
-  private String departureTime;
+  private LocalDateTime departureTime;
 
   @Column(name = "departure_date")
   @Getter
-  private String departureDate;
+  private LocalDate departureDate;
 
   @Column(name = "departure")
   @Getter
@@ -118,7 +120,7 @@ public class MatchingRoom extends BaseEntity {
         .build();
   }
 
-  public static MatchingRoom manualOf(Members roomMaster, String departure, String destination, String description, int maxCapacity, int totalCharge, String departureTime, String departureDate,Long chattingRoomId) {
+  public static MatchingRoom manualOf(Members roomMaster, String departure, String destination, String description, int maxCapacity, int totalCharge, LocalDateTime departureTime, LocalDate departureDate,Long chattingRoomId) {
     return MatchingRoom.builder()
             .capacity(4)
             .roomMaster(roomMaster)

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -70,6 +70,7 @@ public class ManualMatchingService {
                 4,
                 request.getTotalCharge(),
                 request.departureTime(),
+                request.departureDate(),
                 chattingRoom.getId()
         );
 

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -54,7 +54,7 @@ public class ManualMatchingService {
     public Long createManualMatchingRoom(Long userId, ManualMatchingRequest request) {
         Members roomMaster = memberService.findById(userId);
 
-        if (request.getDeparture().equals(request.getDestination())) {
+        if (request.departure().equals(request.destination())) {
             throw new NotEqualStartAndDestinationException();
         }
 
@@ -64,11 +64,11 @@ public class ManualMatchingService {
 
         MatchingRoom matchingRoom = MatchingRoom.manualOf(
                 roomMaster,
-                request.getDeparture(),
-                request.getDestination(),
+                request.departure(),
+                request.destination(),
                 request.description(),
                 4,
-                request.getTotalCharge(),
+                request.totalCharge(),
                 request.departureTime(),
                 request.departureDate(),
                 chattingRoom.getId()

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/MatchingInvitationService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/MatchingInvitationService.java
@@ -54,7 +54,7 @@ public class MatchingInvitationService {
                     MATCH_INVITE,
                     MATCHING_INVITE_TITLE,
                     String.format(MATCHING_INVITE_CONTENT, sender.getNickname()),
-                    MatchingInvitePayload.from(sender.getNickname(), matchingRoomId)
+                    MatchingInvitePayload.from(sender.getNickname(),sender.getProfilePicture(), matchingRoomId)
             );
         }
     }

--- a/src/main/java/com/gachtaxi/domain/notification/entity/payload/MatchingInvitePayload.java
+++ b/src/main/java/com/gachtaxi/domain/notification/entity/payload/MatchingInvitePayload.java
@@ -11,10 +11,12 @@ import lombok.experimental.SuperBuilder;
 public class MatchingInvitePayload extends NotificationPayload {
     private String senderNickname;
     private Long matchingRoomId;
+    private String profilePicture;
 
-    public static MatchingInvitePayload from(String senderNickname, Long matchingRoomId) {
+    public static MatchingInvitePayload from(String senderNickname, String profilePicture, Long matchingRoomId) {
         return MatchingInvitePayload.builder()
                 .senderNickname(senderNickname)
+                .profilePicture(profilePicture)
                 .matchingRoomId(matchingRoomId)
                 .build();
     }


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #125 
Close #


## 🚀 작업 내용
먼저 수동매칭의 출발 날짜(departureDate)가 없어서 예약의 느낌이 약한거같다는 피드백을 반영해서, 미리 예약의 느낌이 좀 더 들도록 수동매칭 생성시 DTO에 날짜정보까지 추가로 반환해주었습니다

또한 수동매칭 생성할때 추가된 필드인 출발 날짜를 수동매칭 리스트로 반환시 함께 반환해주도록 하였고, 
생성한 사람의 프로필아이디와 닉네임, 프로필 사진까지 함께 반환해주도록 수정했습니다

마지막으로 수동매칭 친구 초대시 프로필사진도 함께 반환하도록 하여 직관적으로 보일 수 있도록 변경했습니다

추가적인 내용으로 프론트분들과 ISO 형식으로 통일하려고했던 내용대로, LocalDateTime departureTime, LocalDate departureDate, 으로 각각의 필드를 변경해주었습니다

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/2807e608-3aaf-4da8-b27d-03a4b3287cde)
수동매칭 생성시
![image](https://github.com/user-attachments/assets/63767b20-716a-45a0-96e8-10dcd0360ba1)
수동매칭 리스트
![image](https://github.com/user-attachments/assets/3db26551-8a90-49cb-8c9f-7dbc5f622c9c)
친구초대시 Payload에 프로필 사진까지 포함된 변경내용 몽고DB에서 확인

![image](https://github.com/user-attachments/assets/2904207d-f455-4f22-a1da-25ae24287c16)
변경된 형태로 테스트 완료

## 📢 리뷰 요구사항
간단한 DTO만 변경된 내용이고 다 테스트까지 완료되었지만, 빠진 부분 없는지 잘못된 부분은 없는지 확인 부탁드립니당
