### PR TITLE
Feat #130 채팅방 퇴장시 읽지 않음 수 업데이트

### DIFF
--- a/src/main/java/com/gachtaxi/domain/chat/repository/ChattingMessageMongoRepository.java
+++ b/src/main/java/com/gachtaxi/domain/chat/repository/ChattingMessageMongoRepository.java
@@ -44,13 +44,6 @@ public class ChattingMessageMongoRepository {
         mongoTemplate.updateMulti(query, update, ChattingMessage.class);
     }
 
-    public void decreaseUnreadCount(Long roomId, Long senderId, LocalDateTime lastReadAt) {
-        Query query = new Query().addCriteria(buildCommonCriteria(roomId, lastReadAt, senderId));
-        Update update = new Update().inc("unreadCount", -1);
-
-        mongoTemplate.updateMulti(query, update, ChattingMessage.class);
-    }
-
     private Pair<String, String> getUpdatedMessageRange(Long roomId, LocalDateTime lastReadAt, Long senderId) {
         Query minQuery = new Query().addCriteria(buildCommonCriteria(roomId, lastReadAt, senderId))
                 .with(Sort.by(Sort.Direction.ASC, "_id")).limit(1);

--- a/src/main/java/com/gachtaxi/domain/chat/repository/ChattingMessageMongoRepository.java
+++ b/src/main/java/com/gachtaxi/domain/chat/repository/ChattingMessageMongoRepository.java
@@ -44,6 +44,13 @@ public class ChattingMessageMongoRepository {
         mongoTemplate.updateMulti(query, update, ChattingMessage.class);
     }
 
+    public void decreaseUnreadCount(Long roomId, Long senderId, LocalDateTime lastReadAt) {
+        Query query = new Query().addCriteria(buildCommonCriteria(roomId, lastReadAt, senderId));
+        Update update = new Update().inc("unreadCount", -1);
+
+        mongoTemplate.updateMulti(query, update, ChattingMessage.class);
+    }
+
     private Pair<String, String> getUpdatedMessageRange(Long roomId, LocalDateTime lastReadAt, Long senderId) {
         Query minQuery = new Query().addCriteria(buildCommonCriteria(roomId, lastReadAt, senderId))
                 .with(Sort.by(Sort.Direction.ASC, "_id")).limit(1);

--- a/src/main/java/com/gachtaxi/domain/chat/service/ChattingParticipantService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChattingParticipantService.java
@@ -8,13 +8,10 @@ import com.gachtaxi.domain.chat.entity.enums.MessageType;
 import com.gachtaxi.domain.chat.exception.ChattingParticipantNotFoundException;
 import com.gachtaxi.domain.chat.exception.DuplicateSubscribeException;
 import com.gachtaxi.domain.chat.kafka.KafkaChatPublisher;
-import com.gachtaxi.domain.chat.redis.RedisChatPublisher;
 import com.gachtaxi.domain.chat.repository.ChattingMessageMongoRepository;
 import com.gachtaxi.domain.chat.repository.ChattingParticipantRepository;
 import com.gachtaxi.domain.members.entity.Members;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 
@@ -27,11 +24,7 @@ public class ChattingParticipantService {
     private final ChattingParticipantRepository chattingParticipantRepository;
     private final ChattingMessageMongoRepository chattingMessageMongoRepository;
     private final ChattingRedisService chattingRedisService;
-    private final RedisChatPublisher redisChatPublisher;
     private final KafkaChatPublisher kafkaChatPublisher;
-
-    @Value("${chat.topic}")
-    public String chatTopic;
 
     public void save(ChattingParticipant chattingParticipant) {
         chattingParticipantRepository.save(chattingParticipant);
@@ -82,7 +75,6 @@ public class ChattingParticipantService {
     }
 
     private void reEnterEvent(long roomId, long senderId, String senderName, ReadMessageRange range) {
-        ChannelTopic topic = new ChannelTopic(chatTopic + roomId);
         ChatMessage chatMessage = ChatMessage.of(roomId, senderId, senderName, range, MessageType.READ);
 
         kafkaChatPublisher.publish(chatMessage);

--- a/src/main/java/com/gachtaxi/domain/chat/service/ChattingRoomService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChattingRoomService.java
@@ -2,7 +2,6 @@ package com.gachtaxi.domain.chat.service;
 
 import com.gachtaxi.domain.chat.dto.request.ChatMessage;
 import com.gachtaxi.domain.chat.dto.response.ChattingRoomCountResponse;
-import com.gachtaxi.domain.chat.dto.response.ChattingRoomResponse;
 import com.gachtaxi.domain.chat.entity.ChattingMessage;
 import com.gachtaxi.domain.chat.entity.ChattingParticipant;
 import com.gachtaxi.domain.chat.entity.ChattingRoom;
@@ -10,7 +9,7 @@ import com.gachtaxi.domain.chat.entity.enums.ChatStatus;
 import com.gachtaxi.domain.chat.entity.enums.MessageType;
 import com.gachtaxi.domain.chat.exception.ChattingRoomNotFoundException;
 import com.gachtaxi.domain.chat.kafka.KafkaChatPublisher;
-import com.gachtaxi.domain.chat.redis.RedisChatPublisher;
+import com.gachtaxi.domain.chat.repository.ChattingMessageMongoRepository;
 import com.gachtaxi.domain.chat.repository.ChattingMessageRepository;
 import com.gachtaxi.domain.chat.repository.ChattingRoomRepository;
 import com.gachtaxi.domain.members.entity.Members;
@@ -35,9 +34,9 @@ public class ChattingRoomService {
 
     private final ChattingRoomRepository chattingRoomRepository;
     private final ChattingMessageRepository chattingMessageRepository;
+    private final ChattingMessageMongoRepository chattingMessageMongoRepository;
     private final ChattingParticipantService chattingParticipantService;
     private final MemberService memberService;
-    private final RedisChatPublisher redisChatPublisher;
     private final KafkaChatPublisher kafkaChatPublisher;
     private final ChattingRedisService chattingRedisService;
 
@@ -97,7 +96,9 @@ public class ChattingRoomService {
 
         chattingParticipantService.delete(chattingParticipant);
 
-        publishMessage(roomId, senderId, members.getNickname(),  EXIT_MESSAGE, MessageType.EXIT);
+        chattingMessageMongoRepository.decreaseUnreadCount(roomId, senderId, chattingParticipant.getLastReadAt());
+
+        publishMessage(roomId, senderId, members.getNickname(), EXIT_MESSAGE, MessageType.EXIT);
     }
 
     public ChattingRoom find(long chattingRoomId) {

--- a/src/main/java/com/gachtaxi/domain/chat/service/ChattingRoomService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChattingRoomService.java
@@ -2,6 +2,7 @@ package com.gachtaxi.domain.chat.service;
 
 import com.gachtaxi.domain.chat.dto.request.ChatMessage;
 import com.gachtaxi.domain.chat.dto.response.ChattingRoomCountResponse;
+import com.gachtaxi.domain.chat.dto.response.ReadMessageRange;
 import com.gachtaxi.domain.chat.entity.ChattingMessage;
 import com.gachtaxi.domain.chat.entity.ChattingParticipant;
 import com.gachtaxi.domain.chat.entity.ChattingRoom;
@@ -16,7 +17,7 @@ import com.gachtaxi.domain.members.entity.Members;
 import com.gachtaxi.domain.members.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.util.Pair;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -96,9 +97,9 @@ public class ChattingRoomService {
 
         chattingParticipantService.delete(chattingParticipant);
 
-        chattingMessageMongoRepository.decreaseUnreadCount(roomId, senderId, chattingParticipant.getLastReadAt());
+        Pair<String, String> pair = chattingMessageMongoRepository.updateUnreadCount(chattingRoom.getId(), chattingParticipant.getLastReadAt(), members.getId());
 
-        publishMessage(roomId, senderId, members.getNickname(), EXIT_MESSAGE, MessageType.EXIT);
+        publishMessage(roomId, senderId, members.getNickname(), EXIT_MESSAGE, MessageType.EXIT, ReadMessageRange.from(pair));
     }
 
     public ChattingRoom find(long chattingRoomId) {
@@ -109,11 +110,16 @@ public class ChattingRoomService {
 
     private void publishMessage(long roomId, long senderId, String senderName, String message, MessageType messageType) {
         ChattingMessage chattingMessage = ChattingMessage.of(roomId, senderId, senderName, senderName + message, messageType);
-
         chattingMessageRepository.save(chattingMessage);
-
-        ChannelTopic topic = new ChannelTopic(chatTopic + roomId);
         ChatMessage chatMessage = ChatMessage.from(chattingMessage);
+
+        kafkaChatPublisher.publish(chatMessage);
+    }
+
+    private void publishMessage(long roomId, long senderId, String senderName, String message, MessageType messageType, ReadMessageRange range) {
+        ChattingMessage chattingMessage = ChattingMessage.of(roomId, senderId, senderName, senderName + message, messageType);
+        chattingMessageRepository.save(chattingMessage);
+        ChatMessage chatMessage = ChatMessage.of(roomId, senderId, senderName, range, messageType);
 
         kafkaChatPublisher.publish(chatMessage);
     }

--- a/src/main/java/com/gachtaxi/domain/chat/service/ChattingService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChattingService.java
@@ -10,7 +10,6 @@ import com.gachtaxi.domain.chat.entity.ChattingParticipant;
 import com.gachtaxi.domain.chat.entity.ChattingRoom;
 import com.gachtaxi.domain.chat.exception.WebSocketSessionException;
 import com.gachtaxi.domain.chat.kafka.KafkaChatPublisher;
-import com.gachtaxi.domain.chat.redis.RedisChatPublisher;
 import com.gachtaxi.domain.chat.repository.ChattingMessageRepository;
 import com.gachtaxi.domain.members.entity.Members;
 import com.gachtaxi.domain.members.service.MemberService;
@@ -38,7 +37,6 @@ import static com.gachtaxi.domain.chat.stomp.strategy.StompSubscribeStrategy.CHA
 public class ChattingService {
 
     private final ChattingMessageRepository chattingMessageRepository;
-    private final RedisChatPublisher redisChatPublisher;
     private final KafkaChatPublisher kafkaChatPublisher;
     private final ChattingRoomService chattingRoomService;
     private final ChattingParticipantService chattingParticipantService;

--- a/src/main/java/com/gachtaxi/domain/chat/service/ChattingService.java
+++ b/src/main/java/com/gachtaxi/domain/chat/service/ChattingService.java
@@ -14,12 +14,10 @@ import com.gachtaxi.domain.chat.repository.ChattingMessageRepository;
 import com.gachtaxi.domain.members.entity.Members;
 import com.gachtaxi.domain.members.service.MemberService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,9 +41,6 @@ public class ChattingService {
     private final MemberService memberService;
     private final ChattingRedisService chattingRedisService;
 
-    @Value("${chat.topic}")
-    public String chatTopic;
-
     @Transactional
     public void chat(ChatMessageRequest request, SimpMessageHeaderAccessor accessor) {
         long roomId = getSessionAttribute(accessor, CHAT_ROOM_ID, Long.class);
@@ -59,7 +54,6 @@ public class ChattingService {
 
         chattingMessageRepository.save(chattingMessage);
 
-        ChannelTopic topic = new ChannelTopic(chatTopic + roomId);
         ChatMessage chatMessage = ChatMessage.from(chattingMessage);
 
         kafkaChatPublisher.publish(chatMessage);


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #127 
Close #127 


## 🚀 작업 내용
- 채팅방에 참여하던 인원이 채팅방을 퇴장하는 경우 읽지 않은 수를 감소시켜 혼란을 방지하도록 추가 구현했습니다.
- 기존에 사용하던 mongoDB의 쿼리를 재활용 했습니다 (같은 채팅방에 senderId가 내가 아니고, lastReadAt 이후의 메시지 조회)
- lastReadAt 이후에 온 메시지는 나(나가는 인원)이 읽지 않은 메시지이기 때문에 unReadCount를 1 감소하도록 했습니다.
- 읽음 처리와 마찬가지로 실시간으로 처리가 필요한 메시지의 범위를 프론트로 제공해 실시간 unReadCount 업데이트를 진행해 사용성을 높일 수 있도록 구현했습니다.


## 📸 스크린샷
- 나가기 전 unReadCount
<img width="993" alt="image" src="https://github.com/user-attachments/assets/9a24d947-8f61-4a70-b531-41baa4e70f6e" />


- 퇴장한 이후 다시 조회했을 때 unReadCount
<img width="526" alt="image" src="https://github.com/user-attachments/assets/65bbc21f-7b89-43c2-a3a7-f2fefc942137" />


## 📢 리뷰 요구사항
- 