### PR TITLE
Fix #135 AT RT responsebody 반환

### DIFF
--- a/src/main/java/com/gachtaxi/domain/members/controller/AuthController.java
+++ b/src/main/java/com/gachtaxi/domain/members/controller/AuthController.java
@@ -12,6 +12,7 @@ import com.gachtaxi.domain.members.service.MemberService;
 import com.gachtaxi.global.auth.google.dto.GoogleAuthCode;
 import com.gachtaxi.global.auth.jwt.annotation.CurrentMemberId;
 import com.gachtaxi.global.auth.jwt.dto.JwtTokenDto;
+import com.gachtaxi.global.auth.jwt.dto.RefreshTokenDto;
 import com.gachtaxi.global.auth.jwt.service.JwtService;
 import com.gachtaxi.global.auth.jwt.util.CookieUtil;
 import com.gachtaxi.global.common.mail.dto.request.EmailAddressDto;
@@ -46,20 +47,18 @@ public class AuthController {
     @Operation(summary = "인가 코드를 전달받아, 카카오 소셜 로그인을 진행합니다.")
     public ApiResponse<MemberLoginResponseDto> kakaoLogin(
             @RequestBody @Valid KakaoAuthCode kakaoAuthCode
-            , HttpServletResponse response)
+    )
     {
         LoginDto loginDto = authService.kakaoLogin(kakaoAuthCode.authCode());
-        response.setHeader(ACCESS_TOKEN_SUBJECT, loginDto.jwtTokenDto().accessToken());
 
         if (loginDto.isTemporaryUser()) { // 임시 유저
             return ApiResponse.response(OK, UN_REGISTER.getMessage(), MemberLoginResponseDto.from());
         }
 
-        cookieUtil.setCookie(REFRESH_TOKEN_SUBJECT, loginDto.jwtTokenDto().refreshToken(), response);
         return ApiResponse.response(
                 OK,
                 LOGIN_SUCCESS.getMessage(),
-                MemberLoginResponseDto.from(loginDto.memberResponseDto())
+                MemberLoginResponseDto.from(loginDto.memberResponseDto(), loginDto.jwtTokenDto())
         );
     }
 
@@ -67,20 +66,18 @@ public class AuthController {
     @Operation(summary = "인가 코드를 전달받아, 구글 소셜 로그인을 진행합니다.")
     public ApiResponse<MemberLoginResponseDto> googleLogin(
             @RequestBody @Valid GoogleAuthCode googleAuthCode
-            , HttpServletResponse response)
+    )
     {
         LoginDto loginDto = authService.googleLogin(googleAuthCode.authCode());
-        response.setHeader(ACCESS_TOKEN_SUBJECT, loginDto.jwtTokenDto().accessToken());
 
         if (loginDto.isTemporaryUser()) { // 임시 유저
             return ApiResponse.response(HttpStatus.OK, UN_REGISTER.getMessage(), MemberLoginResponseDto.from());
         }
 
-        cookieUtil.setCookie(REFRESH_TOKEN_SUBJECT, loginDto.jwtTokenDto().refreshToken(), response);
         return ApiResponse.response(
                 OK,
                 LOGIN_SUCCESS.getMessage(),
-                MemberLoginResponseDto.from(loginDto.memberResponseDto())
+                MemberLoginResponseDto.from(loginDto.memberResponseDto(), loginDto.jwtTokenDto())
         );    }
 
     @PostMapping("/refresh")
@@ -135,18 +132,16 @@ public class AuthController {
     @Operation(summary = "사용자 추가 정보 업데이트하는 API 입니다. (프로필, 닉네임, 실명, 학번, 성별,)")
     public ApiResponse<MemberLoginResponseDto> updateMemberSupplement(
             @RequestBody MemberSupplmentRequestDto dto,
-            @CurrentMemberId Long userId,
-            HttpServletResponse response
+            @CurrentMemberId Long userId
     ){
         MemberResponseDto memberDto = memberService.updateMemberSupplement(dto, userId);
         JwtTokenDto jwtTokenDto = jwtService
                 .generateJwtToken(MemberTokenDto.from(memberDto));
-        responseToken(jwtTokenDto, response);
 
         return ApiResponse.response(
                 OK,
                 SUPPLEMENT_UPDATE_SUCCESS.getMessage(),
-                MemberLoginResponseDto.from(memberDto)
+                MemberLoginResponseDto.from(memberDto, jwtTokenDto)
         );
     }
 

--- a/src/main/java/com/gachtaxi/domain/members/controller/AuthController.java
+++ b/src/main/java/com/gachtaxi/domain/members/controller/AuthController.java
@@ -82,15 +82,13 @@ public class AuthController {
 
     @PostMapping("/refresh")
     @Operation(summary = "RefreshToken으로 AccessToken과 RefreshToken을 재발급 하는 API 입니다.")
-    public ApiResponse<Void> reissueRefreshToken(
-            @CookieValue(value = REFRESH_TOKEN_SUBJECT) String refreshToken,
-            HttpServletResponse response
+    public ApiResponse<JwtTokenDto> reissueRefreshToken(
+            @RequestBody @Valid RefreshTokenDto refreshTokenDto
     ) {
 
-        JwtTokenDto jwtTokenDto = jwtService.reissueJwtToken(refreshToken);
-        responseToken(jwtTokenDto, response);
+        JwtTokenDto jwtTokenDto = jwtService.reissueJwtToken(refreshTokenDto.refreshToken());
 
-        return ApiResponse.response(OK, REFRESH_TOKEN_REISSUE.getMessage());
+        return ApiResponse.response(OK, REFRESH_TOKEN_REISSUE.getMessage(), jwtTokenDto);
     }
 
     @PostMapping("/code/mail")

--- a/src/main/java/com/gachtaxi/domain/members/controller/AuthController.java
+++ b/src/main/java/com/gachtaxi/domain/members/controller/AuthController.java
@@ -46,7 +46,8 @@ public class AuthController {
     @PostMapping("/login/kakao")
     @Operation(summary = "인가 코드를 전달받아, 카카오 소셜 로그인을 진행합니다.")
     public ApiResponse<MemberLoginResponseDto> kakaoLogin(
-            @RequestBody @Valid KakaoAuthCode kakaoAuthCode
+            @RequestBody @Valid KakaoAuthCode kakaoAuthCode,
+            HttpServletResponse response
     )
     {
         LoginDto loginDto = authService.kakaoLogin(kakaoAuthCode.authCode());
@@ -55,17 +56,19 @@ public class AuthController {
             return ApiResponse.response(OK, UN_REGISTER.getMessage(), MemberLoginResponseDto.from());
         }
 
+        responseToken(loginDto.jwtTokenDto(), response);
         return ApiResponse.response(
                 OK,
                 LOGIN_SUCCESS.getMessage(),
-                MemberLoginResponseDto.from(loginDto.memberResponseDto(), loginDto.jwtTokenDto())
+                MemberLoginResponseDto.from(loginDto.memberResponseDto())
         );
     }
 
     @PostMapping("/login/google")
     @Operation(summary = "인가 코드를 전달받아, 구글 소셜 로그인을 진행합니다.")
     public ApiResponse<MemberLoginResponseDto> googleLogin(
-            @RequestBody @Valid GoogleAuthCode googleAuthCode
+            @RequestBody @Valid GoogleAuthCode googleAuthCode,
+            HttpServletResponse response
     )
     {
         LoginDto loginDto = authService.googleLogin(googleAuthCode.authCode());
@@ -74,21 +77,24 @@ public class AuthController {
             return ApiResponse.response(HttpStatus.OK, UN_REGISTER.getMessage(), MemberLoginResponseDto.from());
         }
 
+        responseToken(loginDto.jwtTokenDto(), response);
         return ApiResponse.response(
                 OK,
                 LOGIN_SUCCESS.getMessage(),
-                MemberLoginResponseDto.from(loginDto.memberResponseDto(), loginDto.jwtTokenDto())
+                MemberLoginResponseDto.from(loginDto.memberResponseDto())
         );    }
 
     @PostMapping("/refresh")
     @Operation(summary = "RefreshToken으로 AccessToken과 RefreshToken을 재발급 하는 API 입니다.")
-    public ApiResponse<JwtTokenDto> reissueRefreshToken(
-            @RequestBody @Valid RefreshTokenDto refreshTokenDto
+    public ApiResponse<Void> reissueRefreshToken(
+            @RequestHeader(REFRESH_TOKEN_SUBJECT) String refreshToken,
+            HttpServletResponse response
     ) {
 
-        JwtTokenDto jwtTokenDto = jwtService.reissueJwtToken(refreshTokenDto.refreshToken());
+        JwtTokenDto jwtTokenDto = jwtService.reissueJwtToken(refreshToken);
+        responseToken(jwtTokenDto, response);
 
-        return ApiResponse.response(OK, REFRESH_TOKEN_REISSUE.getMessage(), jwtTokenDto);
+        return ApiResponse.response(OK, REFRESH_TOKEN_REISSUE.getMessage());
     }
 
     @PostMapping("/code/mail")
@@ -130,16 +136,18 @@ public class AuthController {
     @Operation(summary = "사용자 추가 정보 업데이트하는 API 입니다. (프로필, 닉네임, 실명, 학번, 성별,)")
     public ApiResponse<MemberLoginResponseDto> updateMemberSupplement(
             @RequestBody MemberSupplmentRequestDto dto,
-            @CurrentMemberId Long userId
+            @CurrentMemberId Long userId,
+            HttpServletResponse response
     ){
         MemberResponseDto memberDto = memberService.updateMemberSupplement(dto, userId);
         JwtTokenDto jwtTokenDto = jwtService
                 .generateJwtToken(MemberTokenDto.from(memberDto));
 
+        responseToken(jwtTokenDto, response);
         return ApiResponse.response(
                 OK,
                 SUPPLEMENT_UPDATE_SUCCESS.getMessage(),
-                MemberLoginResponseDto.from(memberDto, jwtTokenDto)
+                MemberLoginResponseDto.from(memberDto)
         );
     }
 
@@ -149,6 +157,6 @@ public class AuthController {
 
     private void responseToken(JwtTokenDto jwtTokenDto, HttpServletResponse response) {
         response.setHeader(ACCESS_TOKEN_SUBJECT, jwtTokenDto.accessToken());
-        cookieUtil.setCookie(REFRESH_TOKEN_SUBJECT, jwtTokenDto.refreshToken(), response);
+        response.setHeader(REFRESH_TOKEN_SUBJECT, jwtTokenDto.refreshToken());
     }
 }

--- a/src/main/java/com/gachtaxi/domain/members/dto/response/MemberLoginResponseDto.java
+++ b/src/main/java/com/gachtaxi/domain/members/dto/response/MemberLoginResponseDto.java
@@ -8,16 +8,12 @@ import static com.gachtaxi.domain.members.controller.ResponseMessage.*;
 @Builder
 public record MemberLoginResponseDto(
         String status,
-        MemberResponseDto memberResponseDto,
-        String authorization,
-        String refreshToken
+        MemberResponseDto memberResponseDto
 ) {
-    public static MemberLoginResponseDto from(MemberResponseDto memberResponseDto, JwtTokenDto jwtTokenDto) {
+    public static MemberLoginResponseDto from(MemberResponseDto memberResponseDto) {
         return MemberLoginResponseDto.builder()
                 .status(LOGIN_SUCCESS.name())
                 .memberResponseDto(memberResponseDto)
-                .authorization(jwtTokenDto.accessToken())
-                .refreshToken(jwtTokenDto.refreshToken())
                 .build();
     }
 

--- a/src/main/java/com/gachtaxi/domain/members/dto/response/MemberLoginResponseDto.java
+++ b/src/main/java/com/gachtaxi/domain/members/dto/response/MemberLoginResponseDto.java
@@ -1,5 +1,6 @@
 package com.gachtaxi.domain.members.dto.response;
 
+import com.gachtaxi.global.auth.jwt.dto.JwtTokenDto;
 import lombok.Builder;
 
 import static com.gachtaxi.domain.members.controller.ResponseMessage.*;
@@ -7,12 +8,16 @@ import static com.gachtaxi.domain.members.controller.ResponseMessage.*;
 @Builder
 public record MemberLoginResponseDto(
         String status,
-        MemberResponseDto memberResponseDto
+        MemberResponseDto memberResponseDto,
+        String authorization,
+        String refreshToken
 ) {
-    public static MemberLoginResponseDto from(MemberResponseDto memberResponseDto) {
+    public static MemberLoginResponseDto from(MemberResponseDto memberResponseDto, JwtTokenDto jwtTokenDto) {
         return MemberLoginResponseDto.builder()
                 .status(LOGIN_SUCCESS.name())
                 .memberResponseDto(memberResponseDto)
+                .authorization(jwtTokenDto.accessToken())
+                .refreshToken(jwtTokenDto.refreshToken())
                 .build();
     }
 

--- a/src/main/java/com/gachtaxi/global/auth/jwt/dto/JwtTokenDto.java
+++ b/src/main/java/com/gachtaxi/global/auth/jwt/dto/JwtTokenDto.java
@@ -18,8 +18,4 @@ public record JwtTokenDto(
                 .accessToken(accessToken)
                 .build();
     }
-
-    public boolean isTemporaryUser(){
-        return this.refreshToken == null || this.refreshToken.isEmpty();
-    }
 }

--- a/src/main/java/com/gachtaxi/global/auth/jwt/dto/RefreshTokenDto.java
+++ b/src/main/java/com/gachtaxi/global/auth/jwt/dto/RefreshTokenDto.java
@@ -1,0 +1,8 @@
+package com.gachtaxi.global.auth.jwt.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record RefreshTokenDto(
+       @NotNull String refreshToken
+) {
+}

--- a/src/main/java/com/gachtaxi/global/config/SecurityConfig.java
+++ b/src/main/java/com/gachtaxi/global/config/SecurityConfig.java
@@ -69,7 +69,7 @@ public class SecurityConfig {
         configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "https://gachtaxi.site", "https://144.24.85.74.nip.io"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("*"));
-        configuration.setExposedHeaders(Arrays.asList("Authorization", "Set-Cookie"));
+        configuration.setExposedHeaders(Arrays.asList("Authorization"));
         configuration.setAllowCredentials(true);
 
         // /** 들어오는 모든 유형의 URL 패턴을 허용.

--- a/src/main/java/com/gachtaxi/global/config/SecurityConfig.java
+++ b/src/main/java/com/gachtaxi/global/config/SecurityConfig.java
@@ -69,7 +69,7 @@ public class SecurityConfig {
         configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "https://gachtaxi.site", "https://144.24.85.74.nip.io"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("*"));
-        configuration.setExposedHeaders(Arrays.asList("Authorization"));
+        configuration.setExposedHeaders(Arrays.asList("Authorization", "RefreshToken"));
         configuration.setAllowCredentials(true);
 
         // /** 들어오는 모든 유형의 URL 패턴을 허용.


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #132 
Close #132


## 🚀 작업 내용
> AccessToken과 RefreshToken을 RespoonseBody로 반환하도록 수정했습니다. (어플로 마이그레이션)

1. AT과 RT는 ResponseBody로 반환하도록
  - 로그인 시 적용
  - 회원가입 마지막 절차 후에도 적용
2. 토큰 재발급에도 적용

## 📸 스크린샷

### 로그인 성공 시 다음과 같이 반환

```json
// AT, RT ResponseBody로 반환
{
    "code": 200,
    "message": "로그인 성공에 성공했습니다.",
    "data": {
        "status": "LOGIN_SUCCESS",
        "memberResponseDto": {
            "userId": 2,
            "studentNumber": 201935282,
            "nickName": "우석",
            "realName": "송우석",
            "profilePicture": null,
            "email": "koreaioi@gachon.ac.kr",
            "role": "MEMBER",
            "gender": "MALE",
            "accountNumber": "1002559572970"
        },
        "authorization": "eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MiwiZW1haWwiOiJrb3JlYWlvaUBnYWNob24uYWMua3IiLCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJzdWIiOiJBdXRob3JpemF0aW9uIiwiaWF0IjoxNzQxMDg0MDc1LCJleHAiOjE3NDExNzA0NzV9.mqHxnOsNzCLJqQCFEaGRbSVgMdvb883knEtzmY18Buk",
        "refreshToken": "eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MiwiZW1haWwiOiJrb3JlYWlvaUBnYWNob24uYWMua3IiLCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJzdWIiOiJSZWZyZXNoVG9rZW4iLCJpYXQiOjE3NDEwODQwNzUsImV4cCI6MTc0MTY4ODg3NX0.u6yQQYf_vMyuZJGrgWWXwKvc2aCcbSoiTKzshxt7aNs"
    }
}
```


### 토큰 재발급
![image](https://github.com/user-attachments/assets/506d2c8c-5348-4da0-af78-ea3edd528ebf)


## 📢 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성

ResponseBody에 명명된 토큰의 이름인 accessToken과 refreshToken은 프론트 측과 이야기를 나누어 정했습니다!