### PR TITLE
Refactor #137 닉네임 글자 수 제한 추가

### DIFF
--- a/src/main/java/com/gachtaxi/domain/members/exception/ErrorMessage.java
+++ b/src/main/java/com/gachtaxi/domain/members/exception/ErrorMessage.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum ErrorMessage {
     // Member
     DUPLICATED_NICKNAME("중복되는 닉네임입니다."),
+    INVALID_NICKNAME_LENGTH("닉네임은 10자 이하여야 합니다."),
     DUPLICATED_STUDENT_NUMBER("이미 가입된 학번입니다."),
     MEMBER_NOT_FOUND("회원을 찾을 수 없습니다."),
     DUPLICATED_EMAIL("이미 가입된 이메일이에요!"),

--- a/src/main/java/com/gachtaxi/domain/members/exception/InvalidNicknameLengthException.java
+++ b/src/main/java/com/gachtaxi/domain/members/exception/InvalidNicknameLengthException.java
@@ -1,0 +1,12 @@
+package com.gachtaxi.domain.members.exception;
+
+import static com.gachtaxi.domain.members.exception.ErrorMessage.INVALID_NICKNAME_LENGTH;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import com.gachtaxi.global.common.exception.BaseException;
+
+public class InvalidNicknameLengthException extends BaseException {
+    public InvalidNicknameLengthException() {
+        super(BAD_REQUEST, INVALID_NICKNAME_LENGTH.getMessage());
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/members/service/MemberService.java
+++ b/src/main/java/com/gachtaxi/domain/members/service/MemberService.java
@@ -6,6 +6,7 @@ import com.gachtaxi.domain.members.dto.response.MemberResponseDto;
 import com.gachtaxi.domain.members.entity.Members;
 import com.gachtaxi.domain.members.exception.DuplicatedNickNameException;
 import com.gachtaxi.domain.members.exception.DuplicatedStudentNumberException;
+import com.gachtaxi.domain.members.exception.InvalidNicknameLengthException;
 import com.gachtaxi.domain.members.exception.MemberNotFoundException;
 import com.gachtaxi.domain.members.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -68,6 +69,7 @@ public class MemberService {
 
     @Transactional
     public MemberResponseDto updateMemberSupplement(MemberSupplmentRequestDto dto, Long userId) {
+        checkInvalidLengthNickName(dto.nickname());
         checkDuplicatedNickName(dto.nickname());
         checkDuplicatedStudentNumber(dto.studentNumber());
 
@@ -130,6 +132,12 @@ public class MemberService {
                 throw new DuplicatedNickNameException();
             }
         });
+    }
+
+    private void checkInvalidLengthNickName(String nickName) {
+        if (nickName.length() > 10) {
+            throw new InvalidNicknameLengthException();
+        }
     }
 
 }


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #136 
Close #


## 🚀 작업 내용
수동매칭 혹은 나의 매칭 리스트에서 확장되는 상태에서 닉네임이 너무 길 경우에 UI가 깨지거나 가독성이 떨어지는 경우를 방지해서
초기 회원가입시 닉네임 글자수 제한 기능을 구현하였습니다

MemberService 단에서 기존 구현되어있던 updateMemberSupplement 메서드에
추가로 별도의 checkInvalidLengthNickName를 추가해줘서 검증하는 방식으로 구현했습니다

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/d3173665-262d-4498-9e29-c5843afd234e)


## 📢 리뷰 요구사항
없었어용
