### PR TITLE
Feat #138 dm 기능 구현

### DIFF
--- a/src/main/java/com/gachtaxi/domain/friend/dto/response/FriendsResponseDto.java
+++ b/src/main/java/com/gachtaxi/domain/friend/dto/response/FriendsResponseDto.java
@@ -9,22 +9,24 @@ public record FriendsResponseDto(
         Long friendsId,
         String friendsNickName,
         String friendsProfileUrl,
-        Gender gender
+        Gender gender,
+        Long chatRoomId
 ) {
-    public static FriendsResponseDto from(Members friends) {
+    public static FriendsResponseDto of(Members friends, Long chatRoomId) {
         return FriendsResponseDto.builder()
                 .friendsId(friends.getId())
                 .friendsNickName(friends.getNickname())
                 .friendsProfileUrl(friends.getProfilePicture())
                 .gender(friends.getGender())
+                .chatRoomId(chatRoomId)
                 .build();
     }
 
     // Constructor for JPQL Result - DTO Mapping
-    public FriendsResponseDto(Long friendsId, String friendsNickName, String friendsProfileUrl, Gender gender) {
-        this.friendsId = friendsId;
-        this.friendsNickName = friendsNickName;
-        this.friendsProfileUrl = friendsProfileUrl;
-        this.gender = gender;
-    }
+//    public FriendsResponseDto(Long friendsId, String friendsNickName, String friendsProfileUrl, Gender gender) {
+//        this.friendsId = friendsId;
+//        this.friendsNickName = friendsNickName;
+//        this.friendsProfileUrl = friendsProfileUrl;
+//        this.gender = gender;
+//    }
 }

--- a/src/main/java/com/gachtaxi/domain/friend/entity/Friends.java
+++ b/src/main/java/com/gachtaxi/domain/friend/entity/Friends.java
@@ -35,6 +35,8 @@ public class Friends extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private FriendStatus status = PENDING;
 
+    private Long chatRoomId;
+
     public static Friends of(Members sender, Members receiver) {
         return Friends.builder()
                 .sender(sender)
@@ -44,5 +46,9 @@ public class Friends extends BaseEntity {
 
     public void updateStatus(){
         this.status = ACCEPTED;
+    }
+
+    public void updateRoomId(Long roomId){
+        this.chatRoomId = roomId;
     }
 }

--- a/src/main/java/com/gachtaxi/domain/friend/mapper/FriendsMapper.java
+++ b/src/main/java/com/gachtaxi/domain/friend/mapper/FriendsMapper.java
@@ -7,9 +7,9 @@ public class FriendsMapper {
 
     public static FriendsResponseDto toResponseDto(Friends friends, Long memberId) {
         if(friends.getSender().getId().equals(memberId)) {
-            return FriendsResponseDto.from(friends.getReceiver());
+            return FriendsResponseDto.of(friends.getReceiver(), friends.getChatRoomId());
         }else{
-            return FriendsResponseDto.from(friends.getSender());
+            return FriendsResponseDto.of(friends.getSender(), friends.getChatRoomId());
         }
     }
 }

--- a/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
+++ b/src/main/java/com/gachtaxi/domain/friend/service/FriendService.java
@@ -1,5 +1,7 @@
 package com.gachtaxi.domain.friend.service;
 
+import com.gachtaxi.domain.chat.entity.ChattingRoom;
+import com.gachtaxi.domain.chat.service.ChattingRoomService;
 import com.gachtaxi.domain.friend.dto.request.FriendRequestDto;
 import com.gachtaxi.domain.friend.dto.request.FriendUpdateDto;
 import com.gachtaxi.domain.friend.dto.response.FriendsPageableResponse;
@@ -38,6 +40,8 @@ public class FriendService {
     private final FriendRepository friendRepository;
     private final NotificationService notificationService;
     private final MemberService memberService;
+
+    private final ChattingRoomService chattingRoomService;
 
     public static final String FRIEND_REQUEST_CONTENT = "%s 님이 친구 요청을 보냈어요.";
     public static final String FRIEND_REQUEST_TITLE = "친구 요청";
@@ -81,6 +85,9 @@ public class FriendService {
             friendRepository.delete(friendShip);
         }else{
             friendShip.updateStatus();
+            ChattingRoom chattingRoom = chattingRoomService.create();
+
+            friendShip.updateRoomId(chattingRoom.getId());
         }
     }
 
@@ -88,6 +95,7 @@ public class FriendService {
     public void deleteFriend(Long currentId, Long memberId) {
         Friends friendShip = getFriendShip(currentId, memberId);
         friendRepository.delete(friendShip);
+        chattingRoomService.delete(friendShip.getChatRoomId());
     }
 
     /*


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #129 
Close #129 


## 🚀 작업 내용
- 친구 창에서 DM을 가능하게 하기 위해 친구 추가가 완료될 시 채팅방을 생성하고, 친구 테이블에 chatRoomId를 저장하도록 구현했습니다.



## 📸 스크린샷
<img width="323" alt="image" src="https://github.com/user-attachments/assets/5c924392-f558-4433-b236-8d730aee04f4" />


## 📢 리뷰 요구사항
- JPQL 매핑을 위한 코드는 사용하지 않는 것으로 확인해서 일단 주석처리 해뒀습니다. 담당자 분이 삭제해도 된다고 하시면 삭제하겠습니다!