### PR TITLE
Refactor #140 방장 혼자서 마감시 매칭 취소

### DIFF
--- a/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
@@ -44,6 +44,7 @@ public class ManualMatchingController {
     @PostMapping("/creation")
     public ApiResponse<Long> createManualMatchingRoom(@CurrentMemberId Long userId, @Valid @RequestBody ManualMatchingCreateRequest request) {
         Long roomId = manualMatchingService.createManualMatchingRoom(userId, request);
+
         return ApiResponse.response(OK, CREATE_MANUAL_MATCHING_ROOM_SUCCESS.getMessage(), roomId);
     }
 
@@ -51,6 +52,7 @@ public class ManualMatchingController {
     @PostMapping("/join")
     public ApiResponse<Void> joinManualMatchingRoom(@CurrentMemberId Long userId, @Valid @RequestBody ManualMatchingRequest request) {
         manualMatchingService.joinManualMatchingRoom(userId, request.roomId());
+
         return ApiResponse.response(OK, JOIN_MANUAL_MATCHING_ROOM_SUCCESS.getMessage());
     }
 
@@ -58,6 +60,7 @@ public class ManualMatchingController {
     @PostMapping("/invite/reply")
     public ApiResponse<Void> acceptInvitation(@CurrentMemberId Long userId, @Valid @RequestBody ManualMatchingInviteReplyRequest request) {
         matchingInvitationService.acceptInvitation(userId, request);
+
         return ApiResponse.response(OK, ACCEPT_MATCHING_INVITE_SUCCESS.getMessage());
     }
 
@@ -65,6 +68,7 @@ public class ManualMatchingController {
     @PatchMapping("/exit/{roomId}")
     public ApiResponse<Void> leaveManualMatchingRoom(@CurrentMemberId Long userId, @PathVariable Long roomId) {
         manualMatchingService.leaveManualMatchingRoom(userId, roomId);
+
         return ApiResponse.response(OK, LEAVE_MANUAL_MATCHING_ROOM_SUCCESS.getMessage());
     }
 
@@ -73,9 +77,11 @@ public class ManualMatchingController {
     public ApiResponse<Void> completeManualMatchingRoom(@CurrentMemberId Long userId,
                                                      @PathVariable Long roomId) {
         MatchingRoomStatus status = manualMatchingService.completeManualMatchingRoom(userId, roomId);
+
         ResponseMessage responseMessage = (status == MatchingRoomStatus.CANCELLED)
                 ? ResponseMessage.COMPLETE_MANUAL_MATCHING_ROOM_CANCELLED
                 : ResponseMessage.COMPLETE_MANUAL_MATCHING_ROOM_SUCCESS;
+
         return ApiResponse.response(OK, responseMessage.getMessage());
     }
 
@@ -83,6 +89,7 @@ public class ManualMatchingController {
     @GetMapping("/list")
     public ApiResponse<MatchingRoomListResponse> getManualMatchingList(int pageNumber, int pageSize) {
         Slice<MatchingRoomResponse> rooms = manualMatchingService.getManualMatchingList(pageNumber, pageSize);
+
         return ApiResponse.response(OK, GET_MANUAL_MATCHING_LIST_SUCCESS.getMessage(), MatchingRoomListResponse.of(rooms));
     }
 
@@ -90,6 +97,7 @@ public class ManualMatchingController {
     @GetMapping("/my-list")
     public ApiResponse<MatchingRoomListResponse> getMyMatchingList(@CurrentMemberId Long userId, int pageNumber, int pageSize) {
         Slice<MatchingRoomResponse> rooms = manualMatchingService.getMyMatchingList(userId, pageNumber, pageSize);
+
         return ApiResponse.response(OK, GET_MY_MATCHING_LIST_SUCCESS.getMessage(), MatchingRoomListResponse.of(rooms));
     }
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/controller/ManualMatchingController.java
@@ -1,7 +1,6 @@
 package com.gachtaxi.domain.matching.common.controller;
 
 import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.ACCEPT_MATCHING_INVITE_SUCCESS;
-import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.COMPLETE_MANUAL_MATCHING_ROOM_SUCCESS;
 import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.CREATE_MANUAL_MATCHING_ROOM_SUCCESS;
 import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.GET_MANUAL_MATCHING_LIST_SUCCESS;
 import static com.gachtaxi.domain.matching.common.controller.ResponseMessage.GET_MY_MATCHING_LIST_SUCCESS;
@@ -14,6 +13,7 @@ import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingRequest;
 import com.gachtaxi.domain.matching.common.dto.request.ManualMatchingCreateRequest;
 import com.gachtaxi.domain.matching.common.dto.response.MatchingRoomListResponse;
 import com.gachtaxi.domain.matching.common.dto.response.MatchingRoomResponse;
+import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomStatus;
 import com.gachtaxi.domain.matching.common.service.ManualMatchingService;
 import com.gachtaxi.domain.matching.common.service.MatchingInvitationService;
 import com.gachtaxi.global.auth.jwt.annotation.CurrentMemberId;
@@ -72,8 +72,11 @@ public class ManualMatchingController {
     @PatchMapping("/{roomId}/complete")
     public ApiResponse<Void> completeManualMatchingRoom(@CurrentMemberId Long userId,
                                                      @PathVariable Long roomId) {
-        manualMatchingService.completeManualMatchingRoom(userId, roomId);
-        return ApiResponse.response(OK, COMPLETE_MANUAL_MATCHING_ROOM_SUCCESS.getMessage());
+        MatchingRoomStatus status = manualMatchingService.completeManualMatchingRoom(userId, roomId);
+        ResponseMessage responseMessage = (status == MatchingRoomStatus.CANCELLED)
+                ? ResponseMessage.COMPLETE_MANUAL_MATCHING_ROOM_CANCELLED
+                : ResponseMessage.COMPLETE_MANUAL_MATCHING_ROOM_SUCCESS;
+        return ApiResponse.response(OK, responseMessage.getMessage());
     }
 
     @Operation(summary = "수동 매칭방 조회")

--- a/src/main/java/com/gachtaxi/domain/matching/common/controller/ResponseMessage.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/controller/ResponseMessage.java
@@ -23,7 +23,8 @@ public enum ResponseMessage {
   GET_MANUAL_MATCHING_LIST_SUCCESS("수동 매칭방 조회에 성공했습니다."),
   GET_MY_MATCHING_LIST_SUCCESS("내 매칭방 조회에 성공했습니다."),
   ACCEPT_MATCHING_INVITE_SUCCESS("매칭방 초대를 수락/거절이 완료되었습니다"),
-  COMPLETE_MANUAL_MATCHING_ROOM_SUCCESS("매칭이 성공적으로 마감되었습니다.");
+  COMPLETE_MANUAL_MATCHING_ROOM_SUCCESS("매칭이 성공적으로 마감되었습니다."),
+  COMPLETE_MANUAL_MATCHING_ROOM_CANCELLED("혼자서 매칭 마감시 매칭이 취소됩니다.");
 
   private final String message;
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -184,7 +184,7 @@ public class ManualMatchingService {
         수동 매칭 방장 마감
     */
     @Transactional
-    public void completeManualMatchingRoom(Long userId, Long roomId) {
+    public MatchingRoomStatus completeManualMatchingRoom(Long userId, Long roomId) {
         Members user = memberService.findById(userId);
 
         MatchingRoom matchingRoom = findMatchingRoomById(roomId);
@@ -197,8 +197,17 @@ public class ManualMatchingService {
             throw new NotRoomMasterException();
         }
 
+        int currentMemberCount = matchingRoom.getCurrentMemberCount();
+
+        if (currentMemberCount <= 1) {
+            matchingRoom.cancelMatchingRoom();
+            matchingRoomRepository.save(matchingRoom);
+            return MatchingRoomStatus.CANCELLED;
+        }
+
         matchingRoom.completeMatchingRoom();
         matchingRoomRepository.save(matchingRoom);
+        return MatchingRoomStatus.COMPLETE;
     }
 
     /*


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #139 
Close #


## 🚀 작업 내용
이전에 구현했던 방장 매칭 마감의 케이스중 하나인, 방장 혼자서 매칭을 마감하는 경우에는
메세지와 함께 방상태를 CANCELLED로 바꿔주고 취소시켜주는 로직을 추가로 구현하였습니다

## 📸 스크린샷
<img width="786" alt="image" src="https://github.com/user-attachments/assets/e236a9dd-2c95-4291-8a4b-7a3830fd4839" />

방에 다른 참가자와 함께 마감하는 케이스 -> 정상적으로 마감 후, 방상태 COMPLETE

---

<img width="794" alt="image" src="https://github.com/user-attachments/assets/1f9bba59-f2a4-4c0f-8cfc-c87ec99ced94" />
방장 혼자서 마감하는 케이스 -> 매칭방 취소 후, 방상태 CANCELLED

![image](https://github.com/user-attachments/assets/aed85a4c-55dd-4da7-92b2-d01485370fad)

## 📢 리뷰 요구사항
초기에 구현했던 방식은 서비스단에서 early return으로 아래의 형태로 구현했었습니다
```java
if (currentMemberCount <= 1) {
        matchingRoom.cancelMatchingRoom();
        matchingRoomRepository.save(matchingRoom);
        return ResponseMessage.COMPLETE_MANUAL_MATCHING_ROOM_CANCELLED;
    }

    matchingRoom.completeMatchingRoom();
    matchingRoomRepository.save(matchingRoom);
    return ResponseMessage.COMPLETE_MANUAL_MATCHING_ROOM_SUCCESS;
```
근데 고민하다가 서비스는 비즈니스 로직에 집중하고 사용자에게 보여질 응답 메시지는 컨트롤러에서 결정하는게 맞다는 판단이 들어서 현재 방식으로 구현하였습니다. 더 좋은 방법이 있다면 말씀해주시면 감사하겠습니당