### PR TITLE
 Refactor #143 매칭 태그 enum 변경

### DIFF
--- a/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingRoomResponse.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/dto/response/MatchingRoomResponse.java
@@ -1,6 +1,7 @@
 package com.gachtaxi.domain.matching.common.dto.response;
 
 import com.gachtaxi.domain.matching.common.entity.MatchingRoom;
+import com.gachtaxi.domain.members.entity.enums.Gender;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -9,6 +10,7 @@ public record MatchingRoomResponse(
         Long roomId,
         Long chattingRoomId,
         String nickname,
+        Gender gender,
         String profilePicture,
         String description,
         String departure,
@@ -24,6 +26,7 @@ public record MatchingRoomResponse(
                 matchingRoom.getId(),
                 matchingRoom.getChattingRoomId(),
                 matchingRoom.getRoomMaster().getNickname(),
+                matchingRoom.getRoomMaster().getGender(),
                 matchingRoom.getRoomMaster().getProfilePicture(),
                 matchingRoom.getDescription(),
                 matchingRoom.getDeparture(),

--- a/src/main/java/com/gachtaxi/domain/matching/common/entity/enums/Tags.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/entity/enums/Tags.java
@@ -2,5 +2,6 @@ package com.gachtaxi.domain.matching.common.entity.enums;
 
 public enum Tags {
   NO_SMOKE,
-  SAME_GENDER
+  ONLY_MALE,
+  ONLY_FEMALE
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/exception/ErrorMessage.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/exception/ErrorMessage.java
@@ -21,7 +21,8 @@ public enum ErrorMessage {
   NOT_EQUAL_START_DESTINATION("출발지와 도착지는 같을 수 없습니다."),
   NO_SUCH_INVITATION("해당 수동매칭 초대가 존재하지 않습니다."),
   MATCHING_ALREADY_ROOM_FULL("매칭 방이 이미 꽉 찼습니다."),
-  NOT_ROOM_MASTER("방장이 아닌 유저는 마감할 수 없습니다.");
+  NOT_ROOM_MASTER("방장이 아닌 유저는 마감할 수 없습니다."),
+  NOT_MATCH_GENDER("반대 성별로 매칭 태그를 설정할 수 없습니다.");
 
   private final String message;
 }

--- a/src/main/java/com/gachtaxi/domain/matching/common/exception/NotMatchingGenderException.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/exception/NotMatchingGenderException.java
@@ -1,0 +1,12 @@
+package com.gachtaxi.domain.matching.common.exception;
+
+import static com.gachtaxi.domain.matching.common.exception.ErrorMessage.NOT_MATCH_GENDER;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import com.gachtaxi.global.common.exception.BaseException;
+
+public class NotMatchingGenderException extends BaseException {
+    public NotMatchingGenderException() {
+        super(BAD_REQUEST, NOT_MATCH_GENDER.getMessage());
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
+++ b/src/main/java/com/gachtaxi/domain/matching/common/service/ManualMatchingService.java
@@ -9,7 +9,9 @@ import com.gachtaxi.domain.matching.common.entity.MemberMatchingRoomChargingInfo
 import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomStatus;
 import com.gachtaxi.domain.matching.common.entity.enums.MatchingRoomType;
 import com.gachtaxi.domain.matching.common.entity.enums.PaymentStatus;
+import com.gachtaxi.domain.matching.common.entity.enums.Tags;
 import com.gachtaxi.domain.matching.common.exception.NotEqualStartAndDestinationException;
+import com.gachtaxi.domain.matching.common.exception.NotMatchingGenderException;
 import com.gachtaxi.domain.matching.common.exception.NotRoomMasterException;
 import com.gachtaxi.domain.matching.common.exception.PageNotFoundException;
 import com.gachtaxi.domain.matching.common.exception.RoomMasterCantJoinException;
@@ -21,6 +23,7 @@ import com.gachtaxi.domain.matching.common.exception.NotActiveMatchingRoomExcept
 import com.gachtaxi.domain.matching.common.repository.MatchingRoomRepository;
 import com.gachtaxi.domain.matching.common.repository.MemberMatchingRoomChargingInfoRepository;
 import com.gachtaxi.domain.members.entity.Members;
+import com.gachtaxi.domain.members.entity.enums.Gender;
 import com.gachtaxi.domain.members.exception.BlacklistedUserCannotJoinException;
 import com.gachtaxi.domain.members.service.BlacklistService;
 import com.gachtaxi.domain.members.service.MemberService;
@@ -57,6 +60,12 @@ public class ManualMatchingService {
 
         if (request.departure().equals(request.destination())) {
             throw new NotEqualStartAndDestinationException();
+        }
+
+        List<Tags> criteria = request.getCriteria();
+        if ((criteria.contains(Tags.ONLY_MALE) && roomMaster.getGender() != Gender.MALE)
+                || (criteria.contains(Tags.ONLY_FEMALE) && roomMaster.getGender() != Gender.FEMALE)) {
+            throw new NotMatchingGenderException();
         }
 
         ChattingRoom chattingRoom = ChattingRoom.builder()


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #141 
Close #


## 🚀 작업 내용

<img width="376" alt="image" src="https://github.com/user-attachments/assets/b261e548-1588-48e6-810b-31b05b32cdf0" />

- 동성 태그만 설정되도록 하면 유저의 입장에서 사용자가 남성인지 여성인지 명확하게 알지 못하는 문제가 발생하여,
해당 태그를 `ONLY_MALE` 과 `ONLY_FEMALE`로 수정했습니다


- 변경 전인, 동성만 `SAME_GENDER` 태그의 구현 목적인 유저의 안전이랑 편의 등등을 고려해서, 반대 성별으로도 태그 설정이 가능하도록 하는건 악용될 가능성이 있을거같아 같은 성별만 매칭의 목적으로 설계 되도록 예외처리로 막아주었습니다  

- 또한 유저 입장에서 남자만, 여자만 태그 말고도 직관적으로 성별을 확인할 수 있게하기 위해서, 수동매칭 리스트와 나의 매칭 리스트에 성별까지 함께 반환해주도록 수정하였습니다


## 📸 스크린샷

남자만 `Tags`
<img width="635" alt="image" src="https://github.com/user-attachments/assets/4f4561ce-aa59-473f-9f11-7ac5f1443d80" />

반대 성별로 태그 설정해서 방 생성시 예외처리
![image](https://github.com/user-attachments/assets/17c85232-fa71-4f07-b4ea-528c8d5584d4)

기존 형태에서 성별까지 함께 반환
![image](https://github.com/user-attachments/assets/904f2189-84b3-4f81-9e90-adc0c069efa3)


## 📢 리뷰 요구사항

회의때 추가적으로 얘기했던 부분들도 모두 반영해서 테스트했어용
얘기했던 것들 중에서 빠진 부분은 없는지 봐주시면 감사하겠습니다 !