### PR TITLE
Feat #151 공지사항 조회 기능 구현

### DIFF
--- a/src/main/java/com/gachtaxi/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/gachtaxi/domain/notice/controller/NoticeController.java
@@ -1,0 +1,47 @@
+package com.gachtaxi.domain.notice.controller;
+
+
+
+import com.gachtaxi.domain.notice.dto.response.NoticeDTO;
+import com.gachtaxi.domain.notice.dto.response.NoticeDTO.NoticeResponse;
+import com.gachtaxi.domain.notice.dto.response.NoticeListResponse;
+import com.gachtaxi.domain.notice.service.NoticeService;
+import com.gachtaxi.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.gachtaxi.domain.notice.controller.ResponseMessage.GET_NOTICE_ALL_SUCCESS;
+import static com.gachtaxi.domain.notice.controller.ResponseMessage.GET_NOTICE_SUCCESS;
+import static org.springframework.http.HttpStatus.OK;
+
+@Tag(name = "NOTICE", description = "공지사항")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notices")
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    @Operation(summary = "공지사항 단건 상세 조회")
+    @GetMapping("/{noticeId}")
+    public ApiResponse<NoticeResponse> getNoticeDetail(@PathVariable Long noticeId) {
+        NoticeDTO.NoticeResponse response = noticeService.getNoticeDetail(noticeId);
+
+        return ApiResponse.response(OK, GET_NOTICE_SUCCESS.getMessage(), response);
+    }
+
+    @Operation(summary = "공지사항 목록 조회")
+    @GetMapping("/list")
+    public ApiResponse<NoticeListResponse> getNoticeList(@RequestParam int pageNumber, @RequestParam int pageSize) {
+        NoticeListResponse response = noticeService.getNoticeListResponse(pageNumber, pageSize);
+
+        return ApiResponse.response(OK, GET_NOTICE_ALL_SUCCESS.getMessage(), response);
+    }
+
+}

--- a/src/main/java/com/gachtaxi/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/gachtaxi/domain/notice/controller/NoticeController.java
@@ -9,6 +9,7 @@ import com.gachtaxi.domain.notice.service.NoticeService;
 import com.gachtaxi.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -38,7 +39,7 @@ public class NoticeController {
 
     @Operation(summary = "공지사항 목록 조회")
     @GetMapping("/list")
-    public ApiResponse<NoticeListResponse> getNoticeList(@RequestParam int pageNumber, @RequestParam int pageSize) {
+    public ApiResponse<NoticeListResponse> getNoticeList(@RequestParam @Min(0) int pageNumber, @RequestParam @Min(0) int pageSize) {
         NoticeListResponse response = noticeService.getNoticeListResponse(pageNumber, pageSize);
 
         return ApiResponse.response(OK, GET_NOTICE_ALL_SUCCESS.getMessage(), response);

--- a/src/main/java/com/gachtaxi/domain/notice/controller/ResponseMessage.java
+++ b/src/main/java/com/gachtaxi/domain/notice/controller/ResponseMessage.java
@@ -1,0 +1,15 @@
+package com.gachtaxi.domain.notice.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseMessage {
+
+    GET_NOTICE_SUCCESS("채팅방 상세 조회에 성공했습니다."),
+    GET_NOTICE_ALL_SUCCESS("공지사항 전체조회에 성공했습니다.");
+
+    private final String message;
+
+}

--- a/src/main/java/com/gachtaxi/domain/notice/dto/response/NoticeDTO.java
+++ b/src/main/java/com/gachtaxi/domain/notice/dto/response/NoticeDTO.java
@@ -1,0 +1,26 @@
+package com.gachtaxi.domain.notice.dto.response;
+
+import com.gachtaxi.domain.notice.entity.Notice;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public class NoticeDTO {
+
+    public record NoticeResponse(
+            @NotNull Long id,
+            @NotNull String title,
+            @NotNull String content,
+            @NotNull LocalDateTime createDate
+    ) {
+
+        public static NoticeResponse from(Notice notice) {
+            return new NoticeResponse(
+                    notice.getId(),
+                    notice.getTitle(),
+                    notice.getContent(),
+                    notice.getCreateDate()
+            );
+        }
+    }
+
+}

--- a/src/main/java/com/gachtaxi/domain/notice/dto/response/NoticeListResponse.java
+++ b/src/main/java/com/gachtaxi/domain/notice/dto/response/NoticeListResponse.java
@@ -1,0 +1,18 @@
+package com.gachtaxi.domain.notice.dto.response;
+
+import com.gachtaxi.domain.notice.dto.response.NoticeDTO.NoticeResponse;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record NoticeListResponse (
+    List<NoticeDTO.NoticeResponse> notices,
+    NoticePageableResponse pageable
+){
+    public static NoticeListResponse of(List<NoticeResponse> notices, NoticePageableResponse pageable) {
+        return NoticeListResponse.builder()
+                .notices(notices)
+                .pageable(pageable)
+                .build();
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/notice/dto/response/NoticePageableResponse.java
+++ b/src/main/java/com/gachtaxi/domain/notice/dto/response/NoticePageableResponse.java
@@ -1,0 +1,21 @@
+package com.gachtaxi.domain.notice.dto.response;
+
+import lombok.Builder;
+import org.springframework.data.domain.Slice;
+
+@Builder
+public record NoticePageableResponse(
+        int pageNumber,
+        int pageSize,
+        int numberOfElements,
+        boolean isLast
+) {
+    public static NoticePageableResponse of(Slice<?> slice) {
+        return NoticePageableResponse.builder()
+                .pageNumber(slice.getNumber())
+                .pageSize(slice.getSize())
+                .numberOfElements(slice.getNumberOfElements())
+                .isLast(slice.isLast())
+                .build();
+    }
+}

--- a/src/main/java/com/gachtaxi/domain/notice/entity/Notice.java
+++ b/src/main/java/com/gachtaxi/domain/notice/entity/Notice.java
@@ -1,0 +1,30 @@
+package com.gachtaxi.domain.notice.entity;
+
+
+import com.gachtaxi.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class Notice extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+}

--- a/src/main/java/com/gachtaxi/domain/notice/entity/Notice.java
+++ b/src/main/java/com/gachtaxi/domain/notice/entity/Notice.java
@@ -4,9 +4,6 @@ package com.gachtaxi.domain.notice.entity;
 import com.gachtaxi.global.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,10 +14,6 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SuperBuilder
 public class Notice extends BaseEntity {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
 
     private String title;
 

--- a/src/main/java/com/gachtaxi/domain/notice/exception/ErrorMessage.java
+++ b/src/main/java/com/gachtaxi/domain/notice/exception/ErrorMessage.java
@@ -1,0 +1,13 @@
+package com.gachtaxi.domain.notice.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+
+    NOTICE_NOT_FOUND("존재하지 않는 공지사항입니다");
+
+    private final String message;
+}

--- a/src/main/java/com/gachtaxi/domain/notice/exception/NoticeNotFoundException.java
+++ b/src/main/java/com/gachtaxi/domain/notice/exception/NoticeNotFoundException.java
@@ -1,12 +1,12 @@
 package com.gachtaxi.domain.notice.exception;
 
-import static com.gachtaxi.domain.chat.exception.ErrorMessage.CHATTING_ROOM_NOT_FOUND;
+import static com.gachtaxi.domain.notice.exception.ErrorMessage.NOTICE_NOT_FOUND;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import com.gachtaxi.global.common.exception.BaseException;
 
 public class NoticeNotFoundException extends BaseException {
 
-    public NoticeNotFoundException() { super(NOT_FOUND, CHATTING_ROOM_NOT_FOUND.getMessage()); }
+    public NoticeNotFoundException() { super(NOT_FOUND, NOTICE_NOT_FOUND.getMessage()); }
 
 }

--- a/src/main/java/com/gachtaxi/domain/notice/exception/NoticeNotFoundException.java
+++ b/src/main/java/com/gachtaxi/domain/notice/exception/NoticeNotFoundException.java
@@ -1,0 +1,12 @@
+package com.gachtaxi.domain.notice.exception;
+
+import static com.gachtaxi.domain.chat.exception.ErrorMessage.CHATTING_ROOM_NOT_FOUND;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import com.gachtaxi.global.common.exception.BaseException;
+
+public class NoticeNotFoundException extends BaseException {
+
+    public NoticeNotFoundException() { super(NOT_FOUND, CHATTING_ROOM_NOT_FOUND.getMessage()); }
+
+}

--- a/src/main/java/com/gachtaxi/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/gachtaxi/domain/notice/repository/NoticeRepository.java
@@ -1,0 +1,12 @@
+package com.gachtaxi.domain.notice.repository;
+
+import com.gachtaxi.domain.notice.entity.Notice;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+    Slice<Notice> findAllBy(Pageable pageable);
+
+}

--- a/src/main/java/com/gachtaxi/domain/notice/service/NoticeFindService.java
+++ b/src/main/java/com/gachtaxi/domain/notice/service/NoticeFindService.java
@@ -1,0 +1,27 @@
+package com.gachtaxi.domain.notice.service;
+
+
+import com.gachtaxi.domain.notice.entity.Notice;
+import com.gachtaxi.domain.notice.exception.NoticeNotFoundException;
+import com.gachtaxi.domain.notice.repository.NoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeFindService {
+
+    private final NoticeRepository noticeRepository;
+
+    public Notice findByNoticeId(Long noticeId) {
+        return noticeRepository.findById(noticeId)
+                .orElseThrow(NoticeNotFoundException::new);
+    }
+
+    public Slice<Notice> findAllByNotices(Pageable pageable) {
+        return noticeRepository.findAllBy(pageable);
+    }
+
+}

--- a/src/main/java/com/gachtaxi/domain/notice/service/NoticeFindService.java
+++ b/src/main/java/com/gachtaxi/domain/notice/service/NoticeFindService.java
@@ -20,7 +20,7 @@ public class NoticeFindService {
                 .orElseThrow(NoticeNotFoundException::new);
     }
 
-    public Slice<Notice> findAllByNotices(Pageable pageable) {
+    public Slice<Notice> findAllNotices(Pageable pageable) {
         return noticeRepository.findAllBy(pageable);
     }
 

--- a/src/main/java/com/gachtaxi/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/gachtaxi/domain/notice/service/NoticeService.java
@@ -1,6 +1,5 @@
 package com.gachtaxi.domain.notice.service;
 
-import com.gachtaxi.domain.matching.common.exception.PageNotFoundException;
 import com.gachtaxi.domain.notice.dto.response.NoticeDTO;
 import com.gachtaxi.domain.notice.dto.response.NoticeDTO.NoticeResponse;
 import com.gachtaxi.domain.notice.dto.response.NoticeListResponse;
@@ -22,18 +21,6 @@ public class NoticeService {
     private final NoticeFindService noticeFindService;
 
     @Transactional(readOnly = true)
-    public Slice<NoticeDTO.NoticeResponse> getNoticeList(int pageNumber, int pageSize) {
-        if (pageNumber < 0) {
-            throw new PageNotFoundException();
-        }
-
-        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "id"));
-        Slice<Notice> noticeSlice = noticeFindService.findAllNotices(pageable);
-
-        return noticeSlice.map(NoticeDTO.NoticeResponse::from);
-    }
-
-    @Transactional(readOnly = true)
     public NoticeDTO.NoticeResponse getNoticeDetail(Long noticeId) {
         Notice notice = noticeFindService.findByNoticeId(noticeId);
 
@@ -47,6 +34,13 @@ public class NoticeService {
         NoticePageableResponse pageableResponse = NoticePageableResponse.of(noticeSlice);
 
         return NoticeListResponse.of(noticeList, pageableResponse);
+    }
+
+    private Slice<NoticeDTO.NoticeResponse> getNoticeList(int pageNumber, int pageSize) {
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "id"));
+        Slice<Notice> noticeSlice = noticeFindService.findAllNotices(pageable);
+
+        return noticeSlice.map(NoticeDTO.NoticeResponse::from);
     }
 
 }

--- a/src/main/java/com/gachtaxi/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/gachtaxi/domain/notice/service/NoticeService.java
@@ -28,7 +28,7 @@ public class NoticeService {
         }
 
         Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "id"));
-        Slice<Notice> noticeSlice = noticeFindService.findAllByNotices(pageable);
+        Slice<Notice> noticeSlice = noticeFindService.findAllNotices(pageable);
 
         return noticeSlice.map(NoticeDTO.NoticeResponse::from);
     }

--- a/src/main/java/com/gachtaxi/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/gachtaxi/domain/notice/service/NoticeService.java
@@ -1,0 +1,52 @@
+package com.gachtaxi.domain.notice.service;
+
+import com.gachtaxi.domain.matching.common.exception.PageNotFoundException;
+import com.gachtaxi.domain.notice.dto.response.NoticeDTO;
+import com.gachtaxi.domain.notice.dto.response.NoticeDTO.NoticeResponse;
+import com.gachtaxi.domain.notice.dto.response.NoticeListResponse;
+import com.gachtaxi.domain.notice.dto.response.NoticePageableResponse;
+import com.gachtaxi.domain.notice.entity.Notice;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeService {
+
+    private final NoticeFindService noticeFindService;
+
+    @Transactional(readOnly = true)
+    public Slice<NoticeDTO.NoticeResponse> getNoticeList(int pageNumber, int pageSize) {
+        if (pageNumber < 0) {
+            throw new PageNotFoundException();
+        }
+
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "id"));
+        Slice<Notice> noticeSlice = noticeFindService.findAllByNotices(pageable);
+
+        return noticeSlice.map(NoticeDTO.NoticeResponse::from);
+    }
+
+    @Transactional(readOnly = true)
+    public NoticeDTO.NoticeResponse getNoticeDetail(Long noticeId) {
+        Notice notice = noticeFindService.findByNoticeId(noticeId);
+
+        return NoticeDTO.NoticeResponse.from(notice);
+    }
+
+    @Transactional(readOnly = true)
+    public NoticeListResponse getNoticeListResponse(int pageNumber, int pageSize) {
+        Slice<NoticeDTO.NoticeResponse> noticeSlice = getNoticeList(pageNumber, pageSize);
+        List<NoticeResponse> noticeList = noticeSlice.getContent().stream().toList();
+        NoticePageableResponse pageableResponse = NoticePageableResponse.of(noticeSlice);
+
+        return NoticeListResponse.of(noticeList, pageableResponse);
+    }
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #150 
Close #


## 🚀 작업 내용
공지사항 리스트를 무한 스크롤 방식으로 , 공지사항 단건 조회 두가지 API를 구현했습니다

페이지네이션 방식은 다른 도메인에서 했던 내용과 통일해서 구현했고, 이슈에서 작성했었던 대로 현재 수정, 삭제, 작성 기능은 없기때문에 상세조회와 리스트 조회 두가지만 구현하였습니다


## 📸 스크린샷
| 공지사항 상세조회(단건) | 공지사항 리스트 조회 |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/23fd606a-6fab-40a4-abcd-0662ce7b62f5) | ![image](https://github.com/user-attachments/assets/05682550-f991-4501-8c7c-ed8548b582c4) |

| NOT_FOUND 예외처리 | 음수 입력 예외처리 |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/6dc81f28-e45e-4b25-a98d-cec9aa2c50d7) | ![image](https://github.com/user-attachments/assets/916cd769-6e2c-43fc-a754-262521076932) |

## 📢 리뷰 요구사항
가치택시 백엔드에서 오랜만에 작업해보네요

초기에는 공지사항의 생성시간만 반환해주면 되겠다라고 판단했는데, updateDate을 반환해주는 방식도 고민됩니다

현재 무한스크롤 정렬 방식이 내림차순 정렬이라서 생성시간만 반환할 경우 수정된 공지사항이 최신 업데이트 사항을 반영하지 못하는 문제가 발생할 수 있다고 생각이 들었습니당 
물론 지금 게시글 생성시 DB에 직접 넣어주는 방식이여도, 공지사항이 수정되면 가장 최근 순서로 갱신해주는 방향으로 설계하는게 좋을지 
아니면 그대로 초기에 생성한 시간순으로 정렬을 유지하는 편이 좋을지 해당 부분에 대해서 의견이 궁금합니다

```java 
Sort.by(Sort.Direction.DESC, "updateDate")
```

사실 제가 알고있는게 맞다면 DB에서 하드코딩으로 값만 바꾸면 updateDate이 자동으로 최신화 되지 않아서, 크게 상관이 없을거같아 개인적인 생각으론 현행을 유지해도 될거같다는 생각입니다

기존 공지사항을 수정하고싶은데 제일 최신순(가장 위)으로 보여주고싶다 
case 1 : 수정시 createDate를 최신화 해주기
case 2 : 새로 생성하기

