### PR TITLE
Feat #153 어드민 공지사항 작성, 수정, 삭제 구현

### DIFF
--- a/src/main/java/com/gachtaxi/domain/notice/controller/AdminNoticeController.java
+++ b/src/main/java/com/gachtaxi/domain/notice/controller/AdminNoticeController.java
@@ -29,16 +29,14 @@ public class AdminNoticeController {
     private final NoticeAdminService noticeAdminService;
 
     @PostMapping("/notices")
-    public ApiResponse<NoticeResponse> create(@RequestBody @Validated NoticeCreateRequest dto)
-    {
+    public ApiResponse<NoticeResponse> create(@RequestBody @Validated NoticeCreateRequest dto) {
         NoticeDTO.NoticeResponse response = noticeAdminService.createNotice(dto);
 
         return ApiResponse.response(HttpStatus.OK, ResponseMessage.NOTICE_CREATE_SUCCESS.getMessage(), response);
     }
 
     @PatchMapping("/notices/{id}")
-    public ApiResponse<NoticeDTO.NoticeResponse> update(@PathVariable Long id, @RequestBody @Validated NoticeUpdateRequest dto)
-    {
+    public ApiResponse<NoticeDTO.NoticeResponse> update(@PathVariable Long id, @RequestBody @Validated NoticeUpdateRequest dto) {
         NoticeDTO.NoticeResponse response = noticeAdminService.updateNotice(id, dto);
 
         return ApiResponse.response(HttpStatus.OK, ResponseMessage.NOTICE_UPDATE_SUCCESS.getMessage(), response);

--- a/src/main/java/com/gachtaxi/domain/notice/controller/AdminNoticeController.java
+++ b/src/main/java/com/gachtaxi/domain/notice/controller/AdminNoticeController.java
@@ -1,0 +1,54 @@
+package com.gachtaxi.domain.notice.controller;
+
+import com.gachtaxi.domain.notice.dto.request.NoticeCreateRequest;
+import com.gachtaxi.domain.notice.dto.request.NoticeUpdateRequest;
+import com.gachtaxi.domain.notice.dto.response.NoticeDTO;
+import com.gachtaxi.domain.notice.dto.response.NoticeDTO.NoticeResponse;
+import com.gachtaxi.domain.notice.service.NoticeAdminService;
+import com.gachtaxi.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "ADMIN NOTICE", description = "어드민 공지사항")
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminNoticeController {
+
+    private final NoticeAdminService noticeAdminService;
+
+    @PostMapping("/notices")
+    public ApiResponse<NoticeResponse> create(@RequestBody @Validated NoticeCreateRequest dto)
+    {
+        NoticeDTO.NoticeResponse response = noticeAdminService.createNotice(dto);
+
+        return ApiResponse.response(HttpStatus.OK, ResponseMessage.NOTICE_CREATE_SUCCESS.getMessage(), response);
+    }
+
+    @PatchMapping("/notices/{id}")
+    public ApiResponse<NoticeDTO.NoticeResponse> update(@PathVariable Long id, @RequestBody @Validated NoticeUpdateRequest dto)
+    {
+        NoticeDTO.NoticeResponse response = noticeAdminService.updateNotice(id, dto);
+
+        return ApiResponse.response(HttpStatus.OK, ResponseMessage.NOTICE_UPDATE_SUCCESS.getMessage(), response);
+    }
+
+    @DeleteMapping("/notices/{id}")
+    public ApiResponse<Void> delete(@PathVariable Long id) {
+        noticeAdminService.deleteNotice(id);
+
+        return ApiResponse.response(HttpStatus.OK, ResponseMessage.NOTICE_DELETE_SUCCESS.getMessage(), null);
+    }
+
+}

--- a/src/main/java/com/gachtaxi/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/gachtaxi/domain/notice/controller/NoticeController.java
@@ -1,6 +1,9 @@
 package com.gachtaxi.domain.notice.controller;
 
 
+import static com.gachtaxi.domain.notice.controller.ResponseMessage.NOTICE_GET_ALL_SUCCESS;
+import static com.gachtaxi.domain.notice.controller.ResponseMessage.NOTICE_GET_SUCCESS;
+import static org.springframework.http.HttpStatus.OK;
 
 import com.gachtaxi.domain.notice.dto.response.NoticeDTO;
 import com.gachtaxi.domain.notice.dto.response.NoticeDTO.NoticeResponse;
@@ -17,10 +20,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import static com.gachtaxi.domain.notice.controller.ResponseMessage.GET_NOTICE_ALL_SUCCESS;
-import static com.gachtaxi.domain.notice.controller.ResponseMessage.GET_NOTICE_SUCCESS;
-import static org.springframework.http.HttpStatus.OK;
-
 @Tag(name = "NOTICE", description = "공지사항")
 @RestController
 @RequiredArgsConstructor
@@ -34,7 +33,7 @@ public class NoticeController {
     public ApiResponse<NoticeResponse> getNoticeDetail(@PathVariable Long noticeId) {
         NoticeDTO.NoticeResponse response = noticeService.getNoticeDetail(noticeId);
 
-        return ApiResponse.response(OK, GET_NOTICE_SUCCESS.getMessage(), response);
+        return ApiResponse.response(OK, NOTICE_GET_SUCCESS.getMessage(), response);
     }
 
     @Operation(summary = "공지사항 목록 조회")
@@ -42,7 +41,8 @@ public class NoticeController {
     public ApiResponse<NoticeListResponse> getNoticeList(@RequestParam @Min(0) int pageNumber, @RequestParam @Min(0) int pageSize) {
         NoticeListResponse response = noticeService.getNoticeListResponse(pageNumber, pageSize);
 
-        return ApiResponse.response(OK, GET_NOTICE_ALL_SUCCESS.getMessage(), response);
+        return ApiResponse.response(OK, NOTICE_GET_ALL_SUCCESS.getMessage(), response);
     }
 
 }
+

--- a/src/main/java/com/gachtaxi/domain/notice/controller/ResponseMessage.java
+++ b/src/main/java/com/gachtaxi/domain/notice/controller/ResponseMessage.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ResponseMessage {
 
-    NOTICE_GET_SUCCESS("채팅방 상세 조회에 성공했습니다."),
+    NOTICE_GET_SUCCESS("공지사항 상세 조회에 성공했습니다."),
     NOTICE_GET_ALL_SUCCESS("공지사항 전체조회에 성공했습니다."),
 
     // 어드민 관련

--- a/src/main/java/com/gachtaxi/domain/notice/controller/ResponseMessage.java
+++ b/src/main/java/com/gachtaxi/domain/notice/controller/ResponseMessage.java
@@ -7,8 +7,13 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ResponseMessage {
 
-    GET_NOTICE_SUCCESS("채팅방 상세 조회에 성공했습니다."),
-    GET_NOTICE_ALL_SUCCESS("공지사항 전체조회에 성공했습니다.");
+    NOTICE_GET_SUCCESS("채팅방 상세 조회에 성공했습니다."),
+    NOTICE_GET_ALL_SUCCESS("공지사항 전체조회에 성공했습니다."),
+
+    // 어드민 관련
+    NOTICE_CREATE_SUCCESS("공지사항 생성에 성공했습니다."),
+    NOTICE_UPDATE_SUCCESS("공지사항 수정에 성공했습니다."),
+    NOTICE_DELETE_SUCCESS("공지사항 삭제에 성공했습니다.");
 
     private final String message;
 

--- a/src/main/java/com/gachtaxi/domain/notice/dto/request/NoticeCreateRequest.java
+++ b/src/main/java/com/gachtaxi/domain/notice/dto/request/NoticeCreateRequest.java
@@ -1,0 +1,14 @@
+package com.gachtaxi.domain.notice.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record NoticeCreateRequest(
+        @NotBlank
+        @Size(max = 100)
+        String title,
+
+        @NotBlank
+        String content
+
+) {}

--- a/src/main/java/com/gachtaxi/domain/notice/dto/request/NoticeUpdateRequest.java
+++ b/src/main/java/com/gachtaxi/domain/notice/dto/request/NoticeUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.gachtaxi.domain.notice.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record NoticeUpdateRequest(
+        @NotBlank
+        @Size(max = 100)
+        String title,
+
+        @NotBlank
+        String content
+
+) {}

--- a/src/main/java/com/gachtaxi/domain/notice/entity/Notice.java
+++ b/src/main/java/com/gachtaxi/domain/notice/entity/Notice.java
@@ -1,6 +1,7 @@
 package com.gachtaxi.domain.notice.entity;
 
 
+import com.gachtaxi.domain.notice.dto.request.NoticeCreateRequest;
 import com.gachtaxi.global.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -19,5 +20,17 @@ public class Notice extends BaseEntity {
 
     @Column(columnDefinition = "TEXT")
     private String content;
+
+    public static Notice of(NoticeCreateRequest dto) {
+        return Notice.builder()
+                .title(dto.title())
+                .content(dto.content())
+                .build();
+    }
+
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
 
 }

--- a/src/main/java/com/gachtaxi/domain/notice/service/NoticeAdminService.java
+++ b/src/main/java/com/gachtaxi/domain/notice/service/NoticeAdminService.java
@@ -1,0 +1,41 @@
+package com.gachtaxi.domain.notice.service;
+
+import com.gachtaxi.domain.notice.dto.request.NoticeCreateRequest;
+import com.gachtaxi.domain.notice.dto.request.NoticeUpdateRequest;
+import com.gachtaxi.domain.notice.dto.response.NoticeDTO;
+import com.gachtaxi.domain.notice.entity.Notice;
+import com.gachtaxi.domain.notice.repository.NoticeRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeAdminService {
+
+    private final NoticeFindService noticeFindService;
+    private final NoticeRepository noticeRepository;
+
+    @Transactional
+    public NoticeDTO.NoticeResponse createNotice(NoticeCreateRequest dto) {
+        Notice saved = noticeRepository.save(Notice.of(dto));
+
+        return NoticeDTO.NoticeResponse.from(saved);
+    }
+
+    @Transactional
+    public NoticeDTO.NoticeResponse updateNotice(Long id, NoticeUpdateRequest dto) {
+        Notice notice = noticeFindService.findByNoticeId(id);
+        notice.update(dto.title(), dto.content());
+
+        return NoticeDTO.NoticeResponse.from(notice);
+    }
+
+    @Transactional
+    public void deleteNotice(Long id) {
+        Notice notice = noticeFindService.findByNoticeId(id);
+
+        noticeRepository.delete(notice);
+    }
+
+}

--- a/src/main/java/com/gachtaxi/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/gachtaxi/global/config/PermitUrlConfig.java
@@ -28,8 +28,7 @@ public class PermitUrlConfig {
 
     public String[] getAdminUrl(){
         return new String[]{
-                "/api/admin/email/template",
-                "/api/admin/notices/**"
+                "/api/admin/**"
         };
     }
 

--- a/src/main/java/com/gachtaxi/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/gachtaxi/global/config/PermitUrlConfig.java
@@ -29,8 +29,8 @@ public class PermitUrlConfig {
     public String[] getAdminUrl(){
         return new String[]{
                 "/api/admin/email/template",
+                "/api/admin/notices/**"
         };
     }
-
 
 }


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #152 
Close #


## 🚀 작업 내용
어드민 공지사항 작성, 수정, 삭제 기능을 구현했습니다


## 📸 스크린샷

| 공지사항 작성 | 공지사항 수정 |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/4926750a-c180-4d48-9514-d00f188fc99a) | ![image](https://github.com/user-attachments/assets/9dcfe66d-ce0d-4130-9d08-2e8561c27902) |

| 공지사항 삭제 | 권한이 없는 유저가 요청시(토큰 기반) |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/58f687be-ce45-4b47-b6fc-4090d5b74a3e) | ![image](https://github.com/user-attachments/assets/637e6aa2-ba99-4f53-b034-b582132ef06d) |

## 📢 리뷰 요구사항

1. 어드민 전용 API 보호 방식
- 지금 `@PreAuthorize("hasRole('ADMIN')") ` 적용해서 컨트롤러단 전체에서 한번 잠궈주기 + 우석이형이 구현했던 URL 매칭에  `"/api/admin/notices/**"`를 추가해서 이중으로 잠궈주고 있는 방식
- URL 매칭만 사용하면 컨트롤러 내부에서 다른 메서드를 호출할 때 서비스 계층에 직접 권한 검사가 안들어가니까 놓치는 구간이 있을거같았고, `@PreAuthorize`만 사용하면 메서드별 권한을 명시해줄 순 있는데, URL 패턴이 바뀌었을 때 추가나 수정해야될 어노테이션이 늘어날거 같아서, 확장성도 고려해서 설계했는데 현재 방식에 대한 의견이 궁금합니다

2. NoticeMapper 도입
- 이전 PR에서 작업했던 공지사항 단건+목록 조회에서는 `NoticeDTO.NoticeResponse.from(Notice)` 은 DTO 객체를 생성하니까, 팩토리 메서드를 DTO 안에 뒀었고 `Notice.of(NoticeCreateRequest)` 은 Entity 객체를 생성하니까, 팩토리 메서드를 Entity 안에 뒀습니다
- 생성주체에 정적팩토리 메서드 올바르게 선언해준건 맞는거같은데, 매핑 로직을 한곳에 모여있는게 좋을거같다고 생각해서  `NoticeMapper` 도입도 고려중인데 어떻게 생각하는지 의견도 남겨주시면 감사하겠습니당

JWT토큰 부분은 제가 작업했던 부분이 아니여서, 최대한 기존 형식 고려해서 작업했는데 혹시 몰라서 꼼꼼하게 봐주시면 좋을거같아요
명세서는 코드 리뷰 받고, 리팩토링한 다음에 작성할게용
