### PR TITLE
Feat #155 카카오 로그인 모바일 방식 구현

### DIFF
--- a/src/main/java/com/gachtaxi/domain/members/controller/AuthController.java
+++ b/src/main/java/com/gachtaxi/domain/members/controller/AuthController.java
@@ -61,7 +61,7 @@ public class AuthController {
     @PostMapping("/login/mobile/kakao")
     @Operation(summary = "카카오 액세스 토큰을 전달받아, 카카오 모바일 소셜 로그인을 진행합니다.")
     public ApiResponse<MemberLoginResponseDto> loginMobileKakao(
-            @RequestBody KaKaoLoginAccessToken kaKaoLoginAccessToken,
+            @RequestBody @Valid KaKaoLoginAccessToken kaKaoLoginAccessToken,
             HttpServletResponse response
     ) {
         LoginDto loginDto = authService.kakaoMobileLogin(kaKaoLoginAccessToken.accessToken());

--- a/src/main/java/com/gachtaxi/domain/members/controller/AuthController.java
+++ b/src/main/java/com/gachtaxi/domain/members/controller/AuthController.java
@@ -1,9 +1,6 @@
 package com.gachtaxi.domain.members.controller;
 
-import com.gachtaxi.domain.members.dto.request.InactiveMemberAuthCodeRequestDto;
-import com.gachtaxi.domain.members.dto.request.MemberAgreementRequestDto;
-import com.gachtaxi.domain.members.dto.request.MemberSupplmentRequestDto;
-import com.gachtaxi.domain.members.dto.request.MemberTokenDto;
+import com.gachtaxi.domain.members.dto.request.*;
 import com.gachtaxi.domain.members.dto.response.LoginDto;
 import com.gachtaxi.domain.members.dto.response.MemberLoginResponseDto;
 import com.gachtaxi.domain.members.dto.response.MemberResponseDto;
@@ -12,9 +9,7 @@ import com.gachtaxi.domain.members.service.MemberService;
 import com.gachtaxi.global.auth.google.dto.GoogleAuthCode;
 import com.gachtaxi.global.auth.jwt.annotation.CurrentMemberId;
 import com.gachtaxi.global.auth.jwt.dto.JwtTokenDto;
-import com.gachtaxi.global.auth.jwt.dto.RefreshTokenDto;
 import com.gachtaxi.global.auth.jwt.service.JwtService;
-import com.gachtaxi.global.auth.jwt.util.CookieUtil;
 import com.gachtaxi.global.common.mail.dto.request.EmailAddressDto;
 import com.gachtaxi.global.common.mail.service.EmailService;
 import com.gachtaxi.global.common.response.ApiResponse;
@@ -38,19 +33,38 @@ import static org.springframework.http.HttpStatus.OK;
 public class AuthController {
 
     private final EmailService emailService;
-    private final CookieUtil cookieUtil;
     private final AuthService authService;
     private final JwtService jwtService;
     private final MemberService memberService;
 
     @PostMapping("/login/kakao")
     @Operation(summary = "인가 코드를 전달받아, 카카오 소셜 로그인을 진행합니다.")
-    public ApiResponse<MemberLoginResponseDto> kakaoLogin(
+    public ApiResponse<MemberLoginResponseDto> kakaoWebLogin(
             @RequestBody @Valid KakaoAuthCode kakaoAuthCode,
             HttpServletResponse response
     )
     {
-        LoginDto loginDto = authService.kakaoLogin(kakaoAuthCode.authCode());
+        LoginDto loginDto = authService.kakaoWebLogin(kakaoAuthCode.authCode());
+
+        if (loginDto.isTemporaryUser()) { // 임시 유저
+            return ApiResponse.response(OK, UN_REGISTER.getMessage(), MemberLoginResponseDto.from());
+        }
+
+        responseToken(loginDto.jwtTokenDto(), response);
+        return ApiResponse.response(
+                OK,
+                LOGIN_SUCCESS.getMessage(),
+                MemberLoginResponseDto.from(loginDto.memberResponseDto())
+        );
+    }
+
+    @PostMapping("/login/mobile/kakao")
+    @Operation(summary = "카카오 액세스 토큰을 전달받아, 카카오 모바일 소셜 로그인을 진행합니다.")
+    public ApiResponse<MemberLoginResponseDto> loginMobileKakao(
+            @RequestBody KaKaoLoginAccessToken kaKaoLoginAccessToken,
+            HttpServletResponse response
+    ) {
+        LoginDto loginDto = authService.kakaoMobileLogin(kaKaoLoginAccessToken.accessToken());
 
         if (loginDto.isTemporaryUser()) { // 임시 유저
             return ApiResponse.response(OK, UN_REGISTER.getMessage(), MemberLoginResponseDto.from());
@@ -66,7 +80,7 @@ public class AuthController {
 
     @PostMapping("/login/google")
     @Operation(summary = "인가 코드를 전달받아, 구글 소셜 로그인을 진행합니다.")
-    public ApiResponse<MemberLoginResponseDto> googleLogin(
+    public ApiResponse<MemberLoginResponseDto> googleWebLogin(
             @RequestBody @Valid GoogleAuthCode googleAuthCode,
             HttpServletResponse response
     )

--- a/src/main/java/com/gachtaxi/domain/members/dto/request/KaKaoLoginAccessToken.java
+++ b/src/main/java/com/gachtaxi/domain/members/dto/request/KaKaoLoginAccessToken.java
@@ -1,0 +1,6 @@
+package com.gachtaxi.domain.members.dto.request;
+
+public record KaKaoLoginAccessToken(
+        String accessToken
+) {
+}

--- a/src/main/java/com/gachtaxi/domain/members/dto/request/KaKaoLoginAccessToken.java
+++ b/src/main/java/com/gachtaxi/domain/members/dto/request/KaKaoLoginAccessToken.java
@@ -1,6 +1,8 @@
 package com.gachtaxi.domain.members.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record KaKaoLoginAccessToken(
-        String accessToken
+        @NotBlank String accessToken
 ) {
 }

--- a/src/main/java/com/gachtaxi/domain/members/service/AuthService.java
+++ b/src/main/java/com/gachtaxi/domain/members/service/AuthService.java
@@ -28,8 +28,32 @@ public class AuthService {
     private final JwtService jwtService;
     private final MemberService memberService;
 
-    public LoginDto kakaoLogin(String authCode) {
-        KakaoUserInfoResponse userInfo = getKakaoUserInfoResponse(authCode);
+    public LoginDto kakaoWebLogin(String authCode) {
+        KakaoUserInfoResponse userInfo = getKakaoUserInfoByAuthCode(authCode);
+        Long kakaoId = userInfo.id();
+
+        Optional<Members> optionalMember = memberService.findByKakaoId(kakaoId);
+        if(optionalMember.isEmpty()) {
+            return LoginDto.from(
+                    jwtService.generateTmpAccessToken(memberService.saveTmpKakaoMember(kakaoId))
+            );
+        }
+
+        Members members = optionalMember.get();
+        if(members.getStatus() == INACTIVE){
+            return LoginDto.from(
+                    jwtService.generateTmpAccessToken(InactiveMemberDto.of(optionalMember.get()))
+            );
+        }
+
+        return LoginDto.of(
+                jwtService.generateJwtToken(MemberTokenDto.from(members)),
+                MemberResponseDto.from(members)
+        );
+    }
+
+    public LoginDto kakaoMobileLogin(String token) {
+        KakaoUserInfoResponse userInfo = kakaoUtil.requestKakaoProfile(token);
         Long kakaoId = userInfo.id();
 
         Optional<Members> optionalMember = memberService.findByKakaoId(kakaoId);
@@ -53,7 +77,7 @@ public class AuthService {
     }
 
     public LoginDto googleLogin(String authCode) {
-        GoogleUserInfoResponse userInfo = getGoogleUserInfoResponse(authCode);
+        GoogleUserInfoResponse userInfo = getGoogleUserInfoByAuthCode(authCode);
         String googleId = userInfo.id();
 
         Optional<Members> optionalMember = memberService.findByGoogleId(googleId);
@@ -76,18 +100,17 @@ public class AuthService {
         );
     }
 
-
     /*
     * refactoring
     * */
 
-    private KakaoUserInfoResponse getKakaoUserInfoResponse(String authCode) {
+    private KakaoUserInfoResponse getKakaoUserInfoByAuthCode(String authCode) {
         KakaoAccessToken kakaoAccessToken = kakaoUtil.reqeustKakaoToken(authCode);
         KakaoUserInfoResponse userInfo = kakaoUtil.requestKakaoProfile(kakaoAccessToken.access_token());
         return userInfo;
     }
 
-    private GoogleUserInfoResponse getGoogleUserInfoResponse(String authCode) {
+    private GoogleUserInfoResponse getGoogleUserInfoByAuthCode(String authCode) {
         GoogleTokenResponse googleAccessToken = googleUtils.reqeustGoogleToken(authCode);
         GoogleUserInfoResponse userInfo = googleUtils.requestGoogleProfile(googleAccessToken.access_token());
         return userInfo;

--- a/src/main/java/com/gachtaxi/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/gachtaxi/global/config/PermitUrlConfig.java
@@ -7,8 +7,7 @@ public class PermitUrlConfig {
 
     public String[] getPublicUrl(){
         return new String[]{
-                "/auth/login/kakao",
-                "/auth/login/google",
+                "/auth/login/**",
                 "/auth/refresh",
                 "/api/members",
 


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #154 
Close #154 


## 🚀 작업 내용
> PR에서 작업한 내용을 설명

모바일 환경으로 마이그레이션 함에 따라 카카오 모바일 로그인 방식을 구현합니다.

### 기존 카카오 로그인 구현
![기존 카카오 웹 로그인](https://github.com/user-attachments/assets/f959c73c-2d6d-474c-84f0-14cedbe66062)

### 카카오 모바일 로그인 구현
![카카오 모바일 로그인](https://github.com/user-attachments/assets/cb8d209b-5a63-42ea-8ca2-933322212f57)

인가코드를 받아서 카카오 로그인을 수행하던 과정을
액세스 토큰을 받아 카카오 로그인을 수행하도록 구현했습니다.

- 그림상의 AccessToken은 카카오 액세스 토큰을 의미합니다.

기존에 있던 코드를 재사용했습니다.
중복되는 코드가 많아 코드가 기네요....
추후 리팩토링 실시하도록 하겠습니다.

## 📸 스크린샷

### 테스트

실제 AuthCode로 카카오 AccessToken만 따로 받은 다음 해당 AccessToken을 /auth/login/mobile/kakao API에 넣어 테스트 했습니다.

![image](https://github.com/user-attachments/assets/a75b9161-86eb-4e6f-ad13-cfa97323382e)



## 📢 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
